### PR TITLE
Auth0 client secret configurable in Container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+.DS_Store

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -2,4 +2,6 @@
 
 log / stdout "{combined}"
 
+templates /js .js
+
 errors stdout

--- a/web/config/webpack.config.dev.js
+++ b/web/config/webpack.config.dev.js
@@ -79,6 +79,11 @@ module.exports = {
       template: paths.template,
       favicon: paths.favicon
     }),
+    new webpack.DefinePlugin({
+      'process.env': {
+          APP_ENV: JSON.stringify('dev')
+      }
+    }),
     new webpack.HotModuleReplacementPlugin()
   ]
 };

--- a/web/config/webpack.config.prod.js
+++ b/web/config/webpack.config.prod.js
@@ -77,6 +77,11 @@ module.exports = {
       verbose: true,
       dry: false
     }),
+    new webpack.DefinePlugin({
+      'process.env': {
+          APP_ENV: JSON.stringify('docker')
+      }
+    }),
 
     // Minify the compiled JavaScript.
     new webpack.optimize.UglifyJsPlugin({

--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     build: .
     ports:
      - "5001:2015"
+    environment:
+      - AUTH0_CLIENT_ID=MONKEY

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -3,7 +3,7 @@ require('./main.css');
 var Elm = require('./Main.elm');
 
 var options = {
-  allowedConnections: ['Username-Password-Authentication', 'google-oauth2'],
+  allowedConnections: ['Username-Password-Authentication'],
   theme: {
     logo: 'https://www.kindlyops.com/img/compliance_ops_lock_logo.png',
     primaryColor: '#5ab4ac'
@@ -13,7 +13,12 @@ var options = {
     title: "ComplianceOps"
   },
 };
-var CLIENT_ID = "oq2p8P3pe9EO6WdXAJVJSjOE6PR7izX7"; // TODO: make this configurable
+
+if (process.env.APP_ENV === 'dev') {
+  CLIENT_ID = "dLgiofn95h2SnOUllXUdaQaL5S2ShWrk"; // ComplianceOps dev id
+} else {
+  CLIENT_ID = "{{.Env.AUTH0_CLIENT_ID}}";
+}
 var CLIENT_DOMAIN = "auditproof.auth0.com";
 var lock = new Auth0Lock(CLIENT_ID, CLIENT_DOMAIN, options);
 var storedProfile = localStorage.getItem('profile');


### PR DESCRIPTION
The Auth0 client secret is now hardcoded in dev env
only. In a container environment Caddy will template
the env variable AUTH0_CLIENT_SECRET into the js file
when serving it. This allows us to configure the Auth0
secret for production deployments in kubernetes.

A future enhancement would be to make the dev secret
configurable as well via a .env in the root of this project
so that it's possible for other orgs to run this
against their own auth0 account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kindlyops/mappamundi/6)
<!-- Reviewable:end -->
