### PR TITLE
Run tellform server in dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ Once you have docker set up:
     docker-compose run --entrypoint="psql -h db -U postgres -c 'CREATE DATABASE mappamundi_dev'" sqitch
     docker-compose run sqitch deploy
     docker-compose up
-    curl -s http://localhost:3000/ | jq
+    curl -s http://localhost:3001/ | jq
+
+## to access tellform
+
+Open http://localhost:3000/, you can sign in with admin/admin in the dev env.
 
 ## add a database migration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,24 @@ services:
     ports:
       - "2015:2015"
     command: [/code/installrun.sh]
+  tellform:
+      image: tellform/development
+      environment:
+        - REDIS_URL=redis://redis-db:6379
+        - DB_HOST=db
+      links:
+        - redis:redis-db
+        - mongo:db
+      ports:
+        - "4000:3000"
+  mongo:
+      image: mongo
+      ports:
+        - "27017:27017"
+  redis:
+      image: redis
+      ports:
+        - "6379:6379"
   marketing:
     volumes:
       - ./marketing/public:/public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,29 @@
 version: '2'
 services:
+  tellform:
+      image: tellform/production:no_subdomains
+      environment:
+        - REDIS_URL=redis://redis-db:6379
+        - MONGODB_URI=mongodb://mongo-db:27017/mean
+        - CREATE_ADMIN_ACCOUNT=TRUE
+        - SUBDOMAINS_DISABLED=TRUE
+        - BASE_URL=localhost
+        - SOCKET_URL=localhost
+        - SOCKET_PORT=5555
+      links:
+        - redis:redis-db
+        - mongo:mongo-db
+      ports:
+        - "3000:3000"
+        - "5555:5555"
+  mongo:
+      image: mongo
+      ports:
+        - "27017:27017"
+  redis:
+      image: redis
+      ports:
+        - "6379:6379"
   sqitch:
     build:
       context: .
@@ -12,7 +36,7 @@ services:
     image: begriffs/postgrest:v0.3.2.0
     command: [postgrest, "postgres://postgres@db/mappamundi_dev", --jwt-secret, "${POSTGREST_JWT_SECRET}", -a, postgres, --schema, "1"]
     ports:
-      - "3000:3000"
+      - "3001:3000"
     links:
       - db
     env_file: .env
@@ -33,24 +57,6 @@ services:
     ports:
       - "2015:2015"
     command: [/code/installrun.sh]
-  tellform:
-      image: tellform/development
-      environment:
-        - REDIS_URL=redis://redis-db:6379
-        - DB_HOST=db
-      links:
-        - redis:redis-db
-        - mongo:db
-      ports:
-        - "4000:3000"
-  mongo:
-      image: mongo
-      ports:
-        - "27017:27017"
-  redis:
-      image: redis
-      ports:
-        - "6379:6379"
   marketing:
     volumes:
       - ./marketing/public:/public


### PR DESCRIPTION
This runs the server, but doesn't yet have a way to
run setup.js to create the tellform accounts.

Signed-off-by: Elliot Murphy <elliot@elliotmurphy.com>