### PR TITLE
Add configmaps for injecting config into webui code.

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,3 @@
+You must create a configmap for the webui pod.
+
+    kubectl create configmap webui-config --from-literal=AUTH0_CLIENT_ID=foo

--- a/k8s/webui-deployment.yaml
+++ b/k8s/webui-deployment.yaml
@@ -18,3 +18,9 @@ spec:
         ports:
         - name: http
           containerPort: 2015
+        env:
+          - name: AUTH0_CLIENT_ID
+            valueFrom:
+              configMapKeyRef:
+                name: webui-config
+                key: AUTH0_CLIENT_ID


### PR DESCRIPTION
I've deployed this change to kubernetes already, and made a tweak to the Auth0 clients to configure app.havengrc.com as allowed. This means login now works for https://app.havengrc.com!

This works because the Caddy server is templating the generated JS, and injecting AUTH0_CLIENT_ID into the code at runtime by reading from the container environment. The container gets the value from the ConfigMap that is managed in kubernetes.

We'll need the same mechanism for keycloak and other things, this is the first example of getting it working end to end.

Signed-off-by: Elliot Murphy <elliot@elliotmurphy.com>