### PR TITLE
Postgres enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 .npm-debug.log
 web/*.js
+postgresql-data/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     ports:
       - "5434:5432"
     volumes:
-      - ./postgresql-data:/var/lib/postgresql/data
+      - ./postgresql-data:/var/lib/postgresql
   webui:
     working_dir: /code
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
 version: '2'
+volumes:
+  database:
+
 services:
   tellform:
       image: tellform/production:no_subdomains
@@ -46,7 +49,7 @@ services:
     links:
       - db
   api:
-    image: begriffs/postgrest:nightly
+    image: begriffs/postgrest:v0.4.0.0
     command: [postgrest, "/config"]
     ports:
       - "3001:3000"
@@ -62,9 +65,11 @@ services:
     volumes:
       - ./swagger/index.html:/usr/share/nginx/html/index.html
   db:
-    image: postgres:9.5
+    image: postgres:9.6.2
     ports:
       - "5434:5432"
+    volumes:
+      - ./postgresql-data:/var/lib/postgresql/data
   webui:
     working_dir: /code
     volumes:


### PR DESCRIPTION
This pins PostgREST to 4.0.0 now that Joe made us a version tag.
Also upgrades PosgreSQL from 9.5 to 9.6.2, and adds a persistent
data volume to store postgres data so that it will survive even if you
run `docker-compose down` and then `docker-compose up`.