### PR TITLE
Use artifactory to cache npm modules.

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,1 @@
+registry=https://havengrc.jfrog.io/havengrc/api/npm/npm/


### PR DESCRIPTION
This changes the build for the webui container to pull from our project Artifactory server so that npm modules are cached there.