### PR TITLE
Drop elm-mdl, start adding polymer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,24 @@ Haven GRC is a modern risk & compliance dashboard for the cloud.
 
 This exposes a data model using [PostgREST](http://postgrest.com/).
 
-Web front end is in web/README.md
+Web front end is in web/
+
+## Learning Elm
+
+Why use Elm? Elm is both a framework and a language. Here is an excellent 16
+minute video by Richard Feldman that explains the framework architecture choices
+that Elm makes compared to jQuery and Flux. [From jQuery to Flux to Elm](https://www.youtube.com/watch?v=NgwQHGqIMbw).
+
+Elm is also a language that compiles to javascript. Here are some resources for
+learning Elm. In particular, the DailyDrip course is quite good, and provides
+several wonderful example applications that are MIT licensed and have been used
+to help bootstrap this application. You should subscribe to DailyDrip and support
+their work.
+
+ * Free elm course http://courses.knowthen.com/p/elm-for-beginners
+ * Daily Drip elm course that sends you a little bit of code each day to work on https://www.dailydrip.com/topics/elm
+ * Pragmatic Programmers course https://pragmaticstudio.com/elm
+ * Frontend Masters 2-day elm workshop https://frontendmasters.com/workshops/elm/
 
 ## run the service
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -9,6 +9,7 @@ repl-temp-*
 
 # Dependency directories
 node_modules
+bower_components
 
 # Desktop Services Store on macOS
 .DS_Store

--- a/web/README.md
+++ b/web/README.md
@@ -1,13 +1,3 @@
-# Haven GRC
-
-## quick start
-
-You need to have docker available.
-
-```sh
-npm install
-make run
-```
 
 ### Safety at speed
 By connecting activities to policies to values & customer requirements, we help organizations avoid getting bogged down in rules that no longer make sense, and empower people to update practices to use modern tools and techniques without abandoning responsible oversight and administrative controls.
@@ -17,43 +7,6 @@ By connecting activities to policies to values & customer requirements, we help 
 
 This project was bootstrapped with [Create Elm App](https://github.com/halfzebra/create-elm-app) and then ejected.
 
-## Learning Elm
-
-Why use Elm? Elm is both a framework and a language. Here is an excellent 16
-minute video by Richard Feldman that explains the framework architecture choices
-that Elm makes compared to jQuery and Flux. [From jQuery to Flux to Elm](https://www.youtube.com/watch?v=NgwQHGqIMbw).
-
-Elm is also a language that compiles to javascript. Here are some resources for
-learning Elm. In particular, the DailyDrip course is very very good, and provides
-several wonderful example applications that are MIT licensed and have been used
-to help bootstrap this application. You should subscribe to DailyDrip and support
-their work.
-
- * Free elm course http://courses.knowthen.com/p/elm-for-beginners
- * Daily Drip elm course that sends you a little bit of code each day to work on https://www.dailydrip.com/topics/elm
- * Pragmatic Programmers course https://pragmaticstudio.com/elm
- * Frontend Masters 2-day elm workshop https://frontendmasters.com/workshops/elm/
-
-## Installing Elm packages
-
-```sh
-elm-package install <package-name>
-```
-
-## Available scripts
-In the project directory you can run:
-### `make build`
-Builds the app for production to the `dist` folder.  
-
-The build is minified and the filenames include the hashes.  
-Your app is ready to be deployed!
-
-### `make run`
-Runs the app in the development mode.  
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.  
-You will also see any lint errors in the console.
 
 ### `make test`
 Run tests with [node-test-runner](https://github.com/rtfeldman/node-test-runner/tree/master)

--- a/web/bower.json
+++ b/web/bower.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "app-layout": "PolymerElements/app-layout#^2.0.0",
-    "paper-button": "^2.0.0"
+    "paper-button": "^2.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.1"
   }
 }

--- a/web/bower.json
+++ b/web/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "havenweb",
+  "description": "",
+  "main": "",
+  "authors": [
+    "Elliot Murphy <statik@users.noreply.github.com>"
+  ],
+  "license": "apache2",
+  "homepage": "https://github.com/kindlyops/mappamundi",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "app-layout": "PolymerElements/app-layout#^2.0.0",
+    "paper-button": "^2.0.0"
+  }
+}

--- a/web/elm-package.json
+++ b/web/elm-package.json
@@ -9,7 +9,6 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "debois/elm-mdl": "8.1.0 <= v < 9.0.0",
         "elm-community/elm-check": "2.0.1 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",

--- a/web/installrun.sh
+++ b/web/installrun.sh
@@ -3,5 +3,6 @@
 set -x
 
 npm install
+bower install
 # we proxy to the webpack hotreload dev server via caddy
 vendor/linux/caddy -agree -conf /code/Caddyfile-dev

--- a/web/installrun.sh
+++ b/web/installrun.sh
@@ -3,6 +3,6 @@
 set -x
 
 npm install
-bower install
+node_modules/bower/bin/bower install --allow-root
 # we proxy to the webpack hotreload dev server via caddy
 vendor/linux/caddy -agree -conf /code/Caddyfile-dev

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "autoprefixer": "6.5.3",
+    "bower": "^1.8.0",
     "chalk": "1.1.3",
     "clean-webpack-plugin": "0.1.14",
     "css-loader": "0.25.0",

--- a/web/src/State.elm
+++ b/web/src/State.elm
@@ -3,7 +3,6 @@ module State exposing (init, update, subscriptions)
 import Authentication
 import Http
 import Keycloak
-import Material
 import Navigation
 import Ports
 import Regulation.Rest exposing (getRegulations)
@@ -17,9 +16,7 @@ init initialUser location =
       , authModel = (Authentication.init Ports.keycloakShowLock Ports.keycloakLogout initialUser)
       , route =
             Route.init Nothing
-
-      -- (Just location)
-      , mdl = Material.model
+            -- (Just location)
       , selectedTab = 0
       , regulations = []
       }
@@ -36,10 +33,6 @@ update msg model =
                     Authentication.update authMsg model.authModel
             in
                 ( { model | authModel = authModel }, Cmd.map Types.AuthenticationMsg cmd )
-
-        -- When the `Mdl` messages come through, update appropriately.
-        Mdl msg_ ->
-            Material.update Mdl msg_ model
 
         NavigateTo maybeLocation ->
             case maybeLocation of

--- a/web/src/Types.elm
+++ b/web/src/Types.elm
@@ -2,7 +2,6 @@ module Types exposing (..)
 
 import Authentication
 import Http
-import Material
 import Navigation
 import Regulation.Types
 import Route
@@ -12,7 +11,6 @@ type alias Model =
     { count : Int
     , authModel : Authentication.Model
     , route : Route.Model
-    , mdl : Material.Model
     , selectedTab : Int
     , regulations : List Regulation.Types.Regulation
     }
@@ -20,7 +18,6 @@ type alias Model =
 
 type Msg
     = AuthenticationMsg Authentication.Msg
-    | Mdl (Material.Msg Msg)
     | SelectTab Int
     | NavigateTo (Maybe Route.Location)
     | UrlChange Navigation.Location

--- a/web/src/View/Home.elm
+++ b/web/src/View/Home.elm
@@ -3,134 +3,146 @@ module View.Home exposing (view)
 import Authentication
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 import Keycloak
-import Material.Button as Button
-import Material.Color as Color
-import Material.Icon as Icon
-import Material.Layout as Layout
-import Material.List as List
-import Material.Options as Options exposing (Property, css, onClick, when)
-import Material.Scheme
 import Route exposing (Location(..), locFor)
 import Types exposing (Model, Msg)
 
 
 view : Model -> Keycloak.UserProfile -> Html Msg
 view model user =
-    Material.Scheme.topWithScheme Color.Teal Color.LightGreen <|
-        Layout.render Types.Mdl
-            model.mdl
-            [ Layout.fixedHeader
-            , Layout.fixedDrawer
-            , Layout.selectedTab model.selectedTab
-            , Layout.onSelectTab Types.SelectTab
-            ]
-            { header = mainHeader model
-            , drawer = drawer model
-            , tabs = ( [ text "Controls", text "Activities" ], [ Color.background (Color.color Color.Teal Color.S400) ] )
-            , main = [ viewBody model user ]
-            }
-
-
-type alias MenuItem =
-    { text : String
-    , iconName : String
-    , route : Maybe Route.Location
-    }
-
-
-mainHeader : Model -> List (Html Msg)
-mainHeader model =
-    []
-
-
-drawHeader : Model -> Html Msg
-drawHeader model =
-    let
-        ( name, avatar ) =
-            (case Authentication.tryGetUserProfile model.authModel of
-                Nothing ->
-                    ( "unknown", "unknown" )
-
-                Just user ->
-                    ( user.firstName, "" )
-             -- TODO figure out where to get avatar
-            )
-    in
-        (header
-            []
-            [ List.avatarImage avatar [ Options.css "margin-right" "16px" ]
-            , text name
-            ]
-        )
-
-
-drawer : Model -> List (Html Msg)
-drawer model =
-    [ Layout.title [] [ drawHeader model ]
-    , Layout.navigation
-        [ Options.css "flex-grow" "1" ]
-        (List.map (drawerMenuItem model) menuItems)
-    ]
-
-
-menuItems : List MenuItem
-menuItems =
-    [ { text = "Dashboard", iconName = "dashboard", route = Just Home }
-    , { text = "Users", iconName = "group", route = Just Users }
-    , { text = "Last Activity", iconName = "alarm", route = Nothing }
-    , { text = "Timesheets", iconName = "event", route = Nothing }
-    , { text = "Reports", iconName = "list", route = Nothing }
-    , { text = "Organizations", iconName = "store", route = Just Organizations }
-    , { text = "Projects", iconName = "view_list", route = Just Projects }
-    ]
-
-
-drawerMenuItem : Model -> MenuItem -> Html Msg
-drawerMenuItem model menuItem =
-    Layout.link
-        [ Options.onClick <| Types.NavigateTo <| menuItem.route
-        , (if model.route == menuItem.route then
-            Color.text <| Color.primaryContrast
-           else
-            Color.text <| Color.primaryDark
-          )
-        , Options.css "font-weight" "500"
-        , Options.css "cursor" "pointer"
-
-        -- http://outlinenone.com/ TODO: tl;dr don't do this (from Elm Daily Drip example)
-        -- should be using ":focus { outline: 0 }" but can't with inline styles so hack
-        , Options.css "outline" "none"
-        ]
-        [ Icon.view menuItem.iconName
-            [ Options.css "margin-right" "32px"
-            ]
-        , text menuItem.text
-        ]
-
-
-viewBody : Model -> Keycloak.UserProfile -> Html Msg
-viewBody model user =
     div
-        [ style [ ( "padding", "2rem" ) ] ]
-        [ Button.render Types.Mdl
-            [ 0 ]
-            model.mdl
-            [ Options.onClick
-                (Types.AuthenticationMsg Authentication.LogOut)
-            , Options.css "margin" "0 24px"
+        []
+        [ text "This is the logged in view"
+        , div
+            []
+            [ node "paper-button"
+                -- Add this attribute
+                [ attribute "raised" "raised"
+                , onClick (Types.AuthenticationMsg Authentication.LogOut)
+                ]
+                [ text "Logout" ]
             ]
-            [ text "Logout" ]
-        , a [ href "http://localhost:8080/auth/realms/havendev/account/" ] [ text "Edit user profile" ]
-        , (case model.selectedTab of
-            0 ->
-                ul []
-                    (List.map (\r -> li [] [ text r.description ]) model.regulations)
-
-            1 ->
-                text "Second tab content"
-
-            _ ->
-                text "We don't have this tab"
-          )
         ]
+
+
+
+-- view : Model -> Keycloak.UserProfile -> Html Msg
+-- view model user =
+--     Material.Scheme.topWithScheme Color.Teal Color.LightGreen <|
+--         Layout.render Types.Mdl
+--             model.mdl
+--             [ Layout.fixedHeader
+--             , Layout.fixedDrawer
+--             , Layout.selectedTab model.selectedTab
+--             , Layout.onSelectTab Types.SelectTab
+--             ]
+--             { header = mainHeader model
+--             , drawer = drawer model
+--             , tabs = ( [ text "Controls", text "Activities" ], [ Color.background (Color.color Color.Teal Color.S400) ] )
+--             , main = [ viewBody model user ]
+--             }
+--
+--
+-- type alias MenuItem =
+--     { text : String
+--     , iconName : String
+--     , route : Maybe Route.Location
+--     }
+--
+--
+-- mainHeader : Model -> List (Html Msg)
+-- mainHeader model =
+--     []
+--
+--
+-- drawHeader : Model -> Html Msg
+-- drawHeader model =
+--     let
+--         ( name, avatar ) =
+--             (case Authentication.tryGetUserProfile model.authModel of
+--                 Nothing ->
+--                     ( "unknown", "unknown" )
+--
+--                 Just user ->
+--                     ( user.firstName, "" )
+--              -- TODO figure out where to get avatar
+--             )
+--     in
+--         (header
+--             []
+--             [ List.avatarImage avatar [ Options.css "margin-right" "16px" ]
+--             , text name
+--             ]
+--         )
+--
+--
+-- drawer : Model -> List (Html Msg)
+-- drawer model =
+--     [ Layout.title [] [ drawHeader model ]
+--     , Layout.navigation
+--         [ Options.css "flex-grow" "1" ]
+--         (List.map (drawerMenuItem model) menuItems)
+--     ]
+--
+--
+-- menuItems : List MenuItem
+-- menuItems =
+--     [ { text = "Dashboard", iconName = "dashboard", route = Just Home }
+--     , { text = "Users", iconName = "group", route = Just Users }
+--     , { text = "Last Activity", iconName = "alarm", route = Nothing }
+--     , { text = "Timesheets", iconName = "event", route = Nothing }
+--     , { text = "Reports", iconName = "list", route = Nothing }
+--     , { text = "Organizations", iconName = "store", route = Just Organizations }
+--     , { text = "Projects", iconName = "view_list", route = Just Projects }
+--     ]
+--
+--
+-- drawerMenuItem : Model -> MenuItem -> Html Msg
+-- drawerMenuItem model menuItem =
+--     Layout.link
+--         [ Options.onClick <| Types.NavigateTo <| menuItem.route
+--         , (if model.route == menuItem.route then
+--             Color.text <| Color.primaryContrast
+--            else
+--             Color.text <| Color.primaryDark
+--           )
+--         , Options.css "font-weight" "500"
+--         , Options.css "cursor" "pointer"
+--
+--         -- http://outlinenone.com/ TODO: tl;dr don't do this (from Elm Daily Drip example)
+--         -- should be using ":focus { outline: 0 }" but can't with inline styles so hack
+--         , Options.css "outline" "none"
+--         ]
+--         [ Icon.view menuItem.iconName
+--             [ Options.css "margin-right" "32px"
+--             ]
+--         , text menuItem.text
+--         ]
+--
+--
+-- viewBody : Model -> Keycloak.UserProfile -> Html Msg
+-- viewBody model user =
+--     div
+--         [ style [ ( "padding", "2rem" ) ] ]
+--         [ Button.render Types.Mdl
+--             [ 0 ]
+--             model.mdl
+--             [ Options.onClick
+--                 (Types.AuthenticationMsg Authentication.LogOut)
+--             , Options.css "margin" "0 24px"
+--             ]
+--             [ text "Logout" ]
+--         , a [ href "http://localhost:8080/auth/realms/havendev/account/" ] [ text "Edit user profile" ]
+--         , (case model.selectedTab of
+--             0 ->
+--                 ul []
+--                     (List.map (\r -> li [] [ text r.description ]) model.regulations)
+--
+--             1 ->
+--                 text "Second tab content"
+--
+--             _ ->
+--                 text "We don't have this tab"
+--           )
+--         ]

--- a/web/src/View/Login.elm
+++ b/web/src/View/Login.elm
@@ -3,27 +3,22 @@ module View.Login exposing (view)
 import Authentication
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Material.Button as Button
-import Material.Options as Options exposing (css, onClick)
-import Material.Scheme
+import Html.Events exposing (onClick)
 import Types exposing (Model, Msg)
 
 
 view : Model -> Html Msg
 view model =
     div
-        [ class "mdl-grid" ]
-        [ div [ class "mdl-layout-spacer" ] []
-        , div [ class "mdl-cell mdl-cell--4-col" ]
-            [ text "Welcome to Haven GRC"
-            , Button.render Types.Mdl
-                [ 0 ]
-                model.mdl
-                [ Options.onClick (Types.AuthenticationMsg Authentication.ShowLogIn)
-                , css "margin" "0 24px"
+        []
+        [ text "Welcome to Haven GRC"
+        , div
+            []
+            [ node "paper-button"
+                -- Add this attribute
+                [ attribute "raised" "raised"
+                , onClick (Types.AuthenticationMsg Authentication.ShowLogIn)
                 ]
                 [ text "Login" ]
             ]
-        , div [ class "mdl-layout-spacer" ] []
         ]
-        |> Material.Scheme.top

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -29,7 +29,7 @@
     <meta name="theme-color" content="#ffffff">
 
     <script src="/auth/js/keycloak.js"></script>
-    <script src="/bower_components/webcomponentsjs/webcomponents.js"></script>
+    <script src="/bower_components/webcomponentsjs/webcomponents-loader.js"></script>
     <script>
       window.Polymer = {
         dom: 'shadow'

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -29,6 +29,22 @@
     <meta name="theme-color" content="#ffffff">
 
     <script src="/auth/js/keycloak.js"></script>
+    <script src="/bower_components/webcomponentsjs/webcomponents.js"></script>
+    <script>
+      window.Polymer = {
+        dom: 'shadow'
+      };
+    </script>
+    <link rel="import" href="/bower_components/polymer/polymer.html">
+
+    <link rel="import" href="../bower_components/app-layout/app-drawer-layout/app-drawer-layout.html">
+    <link rel="import" href="../bower_components/app-layout/app-drawer/app-drawer.html">
+    <link rel="import" href="../bower_components/app-layout/app-scroll-effects/app-scroll-effects.html">
+    <link rel="import" href="../bower_components/app-layout/app-header/app-header.html">
+    <link rel="import" href="../bower_components/app-layout/app-header-layout/app-header-layout.html">
+    <link rel="import" href="../bower_components/app-layout/app-toolbar/app-toolbar.html">
+
+    <link rel="import" href="/bower_components/paper-button/paper-button.html">
 </head>
 <body>
     <div id="root"></div>

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -15,6 +15,15 @@ var keycloak = Keycloak({
 var storedProfile = localStorage.getItem('profile');
 var storedToken = localStorage.getItem('token');
 var authData = storedProfile && storedToken ? { profile: JSON.parse(storedProfile), token: storedToken } : null;
+
+window.addEventListener('WebComponentsReady', function() {
+  // At this point we are guaranteed that all required polyfills have loaded,
+  // all HTML imports have loaded, and all defined custom elements have upgraded
+  // TODO We have a problem with flickering caused by elm
+  // emitting webcomponent tags before the webcomponent system is ready.
+  // unrecognized tags are simply rendered as an empty div by browers.
+});
+
 var elmApp = Elm.Main.embed(document.getElementById('root'), authData);
 
 options = { redirect_uri: 'http://localhost:2015/' };
@@ -48,8 +57,6 @@ elmApp.ports.keycloakShowLock.subscribe(function(opts) {
     // https://github.com/keycloak/keycloak-js-bower/blob/master/dist/keycloak.js#L506
   });
 });
-
-
 
 // Log out of keycloak
 elmApp.ports.keycloakLogout.subscribe(function(opts) {

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -19,48 +19,49 @@ var authData = storedProfile && storedToken ? { profile: JSON.parse(storedProfil
 window.addEventListener('WebComponentsReady', function() {
   // At this point we are guaranteed that all required polyfills have loaded,
   // all HTML imports have loaded, and all defined custom elements have upgraded
-  // TODO We have a problem with flickering caused by elm
+
+  // We delay Elm.Main.embed because of a problem with flickering caused by elm
   // emitting webcomponent tags before the webcomponent system is ready.
   // unrecognized tags are simply rendered as an empty div by browers.
-});
+  var elmApp = Elm.Main.embed(document.getElementById('root'), authData);
 
-var elmApp = Elm.Main.embed(document.getElementById('root'), authData);
+  options = { redirect_uri: 'http://localhost:2015/' };
+  keycloak.init(options);
 
-options = { redirect_uri: 'http://localhost:2015/' };
-keycloak.init(options);
+  keycloak.onAuthSuccess = function() {
+    console.log("success from keycloak login");
+    var result = { err: null, ok: null };
+    keycloak.loadUserProfile().success(function() {
+          console.log("success from keycloak.loadUserProfile");
+          console.log(keycloak.profile);
+          localStorage.setItem('profile', JSON.stringify(keycloak.profile));
+          localStorage.setItem('token', keycloak.token);
+          result.ok = { profile: keycloak.profile, token: keycloak.token };
+          console.log("sending result ");
+          console.log(result);
+          elmApp.ports.keycloakAuthResult.send(result);
+      }).error(function(errorData) {
+          result.err = { name: "unknown error" };
+          // check for error, error_description
+          // https://github.com/keycloak/keycloak-js-bower/blob/master/dist/keycloak.js#L506
+          elmApp.ports.keycloakAuthResult.send(result);
+    });
+  };
 
-keycloak.onAuthSuccess = function() {
-  console.log("success from keycloak login");
-  var result = { err: null, ok: null };
-  keycloak.loadUserProfile().success(function() {
-        console.log("success from keycloak.loadUserProfile");
-        console.log(keycloak.profile);
-        localStorage.setItem('profile', JSON.stringify(keycloak.profile));
-        localStorage.setItem('token', keycloak.token);
-        result.ok = { profile: keycloak.profile, token: keycloak.token };
-        console.log("sending result ");
-        console.log(result);
-        elmApp.ports.keycloakAuthResult.send(result);
-    }).error(function(errorData) {
-        result.err = { name: "unknown error" };
-        // check for error, error_description
-        // https://github.com/keycloak/keycloak-js-bower/blob/master/dist/keycloak.js#L506
-        elmApp.ports.keycloakAuthResult.send(result);
+  elmApp.ports.keycloakShowLock.subscribe(function(opts) {
+    console.log("calling login");
+    keycloak.login().error(function(errorData) {
+      alert('failed to initialize'); // TODO polish this error case
+      // check for error, error_description
+      // https://github.com/keycloak/keycloak-js-bower/blob/master/dist/keycloak.js#L506
+    });
   });
-};
 
-elmApp.ports.keycloakShowLock.subscribe(function(opts) {
-  console.log("calling login");
-  keycloak.login().error(function(errorData) {
-    alert('failed to initialize'); // TODO polish this error case
-    // check for error, error_description
-    // https://github.com/keycloak/keycloak-js-bower/blob/master/dist/keycloak.js#L506
+  // Log out of keycloak
+  elmApp.ports.keycloakLogout.subscribe(function(opts) {
+    localStorage.removeItem('profile');
+    localStorage.removeItem('token');
+    keycloak.logout();
   });
-});
 
-// Log out of keycloak
-elmApp.ports.keycloakLogout.subscribe(function(opts) {
-  localStorage.removeItem('profile');
-  localStorage.removeItem('token');
-  keycloak.logout();
 });


### PR DESCRIPTION
This removes elm-mdl from the app and switches to using webcomponents and the polymer implementations of Material Design elements.

At application boot time, bower is run after npm and before webpack to install the polymer components based on what is listed in bower.json.

The index.html is adjusted to add the webcomponents polyfill and to add the html imports for some common polymer components.

All the elm-mdl code is removed, and the old elm-mdl layout on the interior page is commented out for temporary reference.

The login and logout buttons still work, and are now paper-button tags using the paper-button component.
