### PR TITLE
Drawer

### DIFF
--- a/web/src/View/Home.elm
+++ b/web/src/View/Home.elm
@@ -56,9 +56,6 @@ view model user =
                     , class "main-header"
                     ]
                     [ appToolbar
-                        []
-                        []
-                    , appToolbar
                         [ id "profiletoolbar" ]
                         [ text user.username ]
                     ]

--- a/web/src/main.scss
+++ b/web/src/main.scss
@@ -34,6 +34,18 @@ app-toolbar {
   border-radius: 5px;
 }
 
+.main-header{
+  left:0px !important;
+}
+
+#drawer {
+  top:64px;
+}
+
+#drawer > app-header-layout{
+  position: static;
+}
+
 #drawer > app-header-layout > iron-selector {
   cursor: pointer;
   > div > iron-icon {
@@ -51,8 +63,8 @@ app-drawer-layout:not([narrow]) [drawer-toggle] {
 
 #drawerlogo{
   position: absolute;
-  bottom: 5%;
-  left: 34%;
+  bottom: 150px;
+  left: 88px;
 }
 
 [hidden] {

--- a/web/src/main.scss
+++ b/web/src/main.scss
@@ -40,6 +40,7 @@ app-toolbar {
 
 #drawer {
   top:64px;
+  box-shadow: #DBDBDC 5px 8px 18px;
 }
 
 #drawer > app-header-layout{


### PR DESCRIPTION
Deleted the extra appToolbar, since it was just supposed to be filling in for the header space.

Various css changes/adds to make header full-width and added box shadow.

TODO: I want to find a better way for the drawer to show the user menu item instead of using app-header and app-header-layout. I'm going to look into using iron-dropdown and iron-list.