### PR TITLE
Pull avatar from gravatar.com

### DIFF
--- a/web/elm-package.json
+++ b/web/elm-package.json
@@ -17,6 +17,7 @@
         "elm-lang/svg": "2.0.0 <= v < 3.0.0",
         "evancz/url-parser": "2.0.1 <= v < 3.0.0",
         "gampleman/elm-visualization": "1.1.1 <= v < 2.0.0",
+        "kuzzmi/elm-gravatar": "2.0.1 <= v < 3.0.0",
         "rtfeldman/elm-css": "8.2.0 <= v < 9.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/web/src/View/Home.elm
+++ b/web/src/View/Home.elm
@@ -1,6 +1,7 @@
 module View.Home exposing (view)
 
 import Authentication
+import Gravatar
 import View.Centroid as Centroid
 import Date
 import List exposing (..)
@@ -40,6 +41,19 @@ header model =
         ]
 
 
+getGravatar : String -> String
+getGravatar email =
+    let
+        options =
+            Gravatar.defaultOptions
+                |> Gravatar.withDefault Gravatar.Identicon
+
+        url =
+            Gravatar.url options email
+    in
+        "https:" ++ url
+
+
 view : Model -> Keycloak.UserProfile -> Html Msg
 view model user =
     appDrawerLayout
@@ -58,14 +72,14 @@ view model user =
                     [ appToolbar
                         [ id "profiletoolbar" ]
                         [ div [ class "user-container" ]
-                              [ node "iron-image"
-                                  [
-                                    attribute "sizing" "contain"
-                                  , attribute "src" "http://lorempixel.com/400/400"
-                                  , class "user-avatar"
-                                  ] []
-                              , p [ class "user-name" ] [ text user.username ]
-                              ]
+                            [ node "iron-image"
+                                [ attribute "sizing" "contain"
+                                , attribute "src" (getGravatar user.username)
+                                , class "user-avatar"
+                                ]
+                                []
+                            , p [ class "user-name" ] [ text user.username ]
+                            ]
                         , node "paper-menu-button"
                             [ attribute "vertical-align" "top"
                             , class "user-menu"
@@ -82,28 +96,31 @@ view model user =
                                 ]
                                 [ a [ href "/auth/realms/havendev/account/" ]
                                     [ node "paper-item"
-                                      [] [ text "Edit Account" ]
+                                        []
+                                        [ text "Edit Account" ]
                                     ]
                                 , a [ href "#" ]
                                     [ node "paper-item"
-                                      [ onClick (Types.AuthenticationMsg Authentication.LogOut) ] [ text "Log Out" ]
+                                        [ onClick (Types.AuthenticationMsg Authentication.LogOut) ]
+                                        [ text "Log Out" ]
                                     ]
                                 ]
                             ]
                         ]
                     ]
                 , div [ class "iron-selector-container" ]
-                      [ ironSelector
+                    [ ironSelector
                         [ class "nav-menu"
                         , attribute "attr-for-selected" "name"
                         , attribute "selected" (selectedItem model)
                         ]
                         (List.map drawerMenuItem menuItems)
-                      , div [ class "drawer-logo"]
+                    , div [ class "drawer-logo" ]
                         [ img
-                          [ attribute "src" "/img/logo.png" ] []
+                            [ attribute "src" "/img/logo.png" ]
+                            []
                         ]
-                      ]
+                    ]
                 ]
             ]
         , header model


### PR DESCRIPTION
This swaps out the user image to pull from gravatar.com, using an elm library to generate the md5 hash of the user email address in order to generate the gravatar url.

This PR is targeted to merge into @laurencaitlan user-avatar branch, as it builds on the excellent work there.