### PR TITLE
Add mailhog service for trapping emails in dev.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .npm-debug.log
 web/*.js
 postgresql-data/*
+mailhog/*

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Open http://localhost:5000/
 
     curl -s http://localhost:3001/ | jq
 
+# to see emails sent from Haven / keycloak
+
+Open http://localhost:8025, you can use mailhog to see messages stored in memory
+
 ## to export keycloak realm data (to refresh the dev users)
 
 First enter the keycloak container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ services:
   #     dockerfile: ./marketing/Dockerfile
   #   ports:
   #     - "5000:2015"
+  mailhog:
+    image: mailhog/mailhog:v1.0.0
+    ports:
+      - "8025:8025"
+      - "1025:1025"
   keycloak:
     image: havengrc-docker.jfrog.io/jboss/keycloak-postgres:3.2.1.Final
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,11 @@ services:
     ports:
       - "8025:8025"
       - "1025:1025"
+    environment:
+      - MH_STORAGE=maildir
+      - MH_MAILDIR_PATH=/maildir
+    volumes:
+      - ./mailhog/maildir:/maildir
   keycloak:
     image: havengrc-docker.jfrog.io/jboss/keycloak-postgres:3.2.1.Final
     environment:


### PR DESCRIPTION
This makes it easy to handle email in dev. MailHog is a special
SMTP server that runs in dev and displays emails in a web UI
running on port 8025 instead of delivering them. Optionally you
can then release emails out to a real 3rd party SMTP server

For example, here is a screenshot of MailHog displaying the verification email from KeyCloak after I registered a new user.
<img width="1166" alt="mailhog" src="https://user-images.githubusercontent.com/983/29754477-e290d9cc-8b53-11e7-9620-6bdbc6f53896.png">

