### PR TITLE
Error message snackbar

### DIFF
--- a/webui/src/Ports.elm
+++ b/webui/src/Ports.elm
@@ -15,4 +15,4 @@ port keycloakLogout : () -> Cmd msg
 port setTitle : String -> Cmd msg
 
 
-port applyMDC : () -> Cmd msg
+port showError : String -> Cmd msg

--- a/webui/src/State.elm
+++ b/webui/src/State.elm
@@ -116,6 +116,9 @@ update msg model =
             in
                 ( model, Cmd.none )
 
+        ShowError value ->
+            model ! [ Ports.showError value ]
+
 
 subscriptions : a -> Sub Msg
 subscriptions model =

--- a/webui/src/State.elm
+++ b/webui/src/State.elm
@@ -31,6 +31,22 @@ init initialUser location =
         )
 
 
+getHTTPErrorMessage : Http.Error -> String
+getHTTPErrorMessage error =
+    case error of
+        Http.NetworkError ->
+            "Is the server running?"
+
+        Http.BadStatus response ->
+            (toString response.status)
+
+        Http.BadPayload message _ ->
+            "Decoding Failed: " ++ message
+
+        _ ->
+            (toString error)
+
+
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -85,36 +101,13 @@ update msg model =
                 { model | newComment = emptyNewComment, comments = morecomments } ! []
 
         NewComment (Err error) ->
-            -- TODO display the error in the UI
-            let
-                _ =
-                    Debug.log "DEBUG: error when POSTing comment " error
-            in
-                ( model, Cmd.none )
+            model ! [ Ports.showError (getHTTPErrorMessage error) ]
 
         NewComments (Ok comments) ->
             { model | comments = comments } ! []
 
         NewComments (Err error) ->
-            let
-                errorMessage =
-                    case error of
-                        Http.NetworkError ->
-                            "Is the server running?"
-
-                        Http.BadStatus response ->
-                            (toString response.status)
-
-                        Http.BadPayload message _ ->
-                            "Decoding Failed: " ++ message
-
-                        _ ->
-                            (toString error)
-
-                _ =
-                    Debug.log "DEBUG: " errorMessage
-            in
-                ( model, Cmd.none )
+            model ! [ Ports.showError (getHTTPErrorMessage error) ]
 
         ShowError value ->
             model ! [ Ports.showError value ]

--- a/webui/src/Types.elm
+++ b/webui/src/Types.elm
@@ -26,3 +26,4 @@ type Msg
     | NewComments (Result Http.Error (List Comment.Types.Comment))
     | NewComment (Result Http.Error (List Comment.Types.Comment))
     | SetCommentMessageInput String
+    | ShowError String

--- a/webui/src/View/Home.elm
+++ b/webui/src/View/Home.elm
@@ -128,6 +128,22 @@ selectedItem model =
                 String.toLower item.text
 
 
+snackBar : Model -> Html Msg
+snackBar model =
+    div
+        [ id "error-snackbar"
+        , class "mdc-snackbar"
+        , attribute "aria-live" "assertive"
+        , attribute "aria-atomic" "true"
+        , attribute "aria-hidden" "true"
+          -- , onClick (Types.ShowError "this is an error message")
+        ]
+        [ div [ class "mdc-snackbar__text" ] []
+        , div [ class "mdc-snackbar__action-wrapper" ]
+            [ button [ class "mdc-snackbar__action-button" ] [] ]
+        ]
+
+
 body : Model -> Html Msg
 body model =
     div [ id "content" ]
@@ -149,6 +165,7 @@ body model =
 
             Just _ ->
                 notFoundBody model
+        , snackBar model
         ]
 
 
@@ -160,7 +177,15 @@ dashboardBody model =
     in
         div
             []
-            [ Centroid.view data ]
+            [ Centroid.view data
+            , br [] []
+            , button
+                [ class "mdc-button mdc-button--raised mdc-button--primary"
+                , attribute "data-mdc-auto-init" "MDCRipple"
+                , onClick (Types.ShowError "this is an error message")
+                ]
+                [ text "Show Error" ]
+            ]
 
 
 reportsBody : Model -> Html Msg
@@ -187,8 +212,6 @@ commentsForm : Model -> Html Msg
 commentsForm model =
     div
         [ id "Comments" ]
-        -- TODO wire up a handler to save the data from these inputs into
-        -- our model when they change
         [ div []
             [ div
                 [ class "mdc-textfield"

--- a/webui/src/index.js
+++ b/webui/src/index.js
@@ -24,6 +24,12 @@ document.arrive(".mdc-textfield", function(){
   window.mdc.autoInit(document, () => { });
 });
 
+
+elmApp.ports.showError.subscribe(function(messageString) {
+  let snack = mdc.snackbar.MDCSnackbar.attachTo(document.querySelector('.mdc-snackbar'));
+  snack.show({ message: messageString });
+});
+
 document.arrive("#MenuButton", function(){
   let drawer = new mdc.drawer.MDCPersistentDrawer(document.getElementById('MenuDrawer'));
   document.getElementById('MenuButton').addEventListener('click', function () {


### PR DESCRIPTION
This introduces the material design snackbar, which the way to show a message notification for example a network error - similar to a rails/bootstrap flash message. The styling may need to be adjusted but seems pretty decent to start with.

There is an error button on the dashboard page that will display a fake error, and the HTTP ajax requests are now wired up to display error messages in the UI. The most common time this happens right now is if you try to post a comment on the comments page after being logged for more than 5 minutes. The JWT token expires, and you get 401 access denied from the API call.

You can see the snackbar at the bottom of the screenshot, it animates back out after a brief delay.

<img width="463" alt="haven_grc" src="https://user-images.githubusercontent.com/983/32033280-bac80622-b9d9-11e7-91b7-b0d7e930bae3.png">
