### PR TITLE
Tweak colors

### DIFF
--- a/webui/src/Ports.elm
+++ b/webui/src/Ports.elm
@@ -15,4 +15,4 @@ port keycloakLogout : () -> Cmd msg
 port setTitle : String -> Cmd msg
 
 
-port applyMDC : () -> Cmd msg
+port showError : String -> Cmd msg

--- a/webui/src/State.elm
+++ b/webui/src/State.elm
@@ -116,6 +116,9 @@ update msg model =
             in
                 ( model, Cmd.none )
 
+        ShowError value ->
+            model ! [ Ports.showError value ]
+
 
 subscriptions : a -> Sub Msg
 subscriptions model =

--- a/webui/src/State.elm
+++ b/webui/src/State.elm
@@ -31,6 +31,22 @@ init initialUser location =
         )
 
 
+getHTTPErrorMessage : Http.Error -> String
+getHTTPErrorMessage error =
+    case error of
+        Http.NetworkError ->
+            "Is the server running?"
+
+        Http.BadStatus response ->
+            (toString response.status)
+
+        Http.BadPayload message _ ->
+            "Decoding Failed: " ++ message
+
+        _ ->
+            (toString error)
+
+
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -85,36 +101,13 @@ update msg model =
                 { model | newComment = emptyNewComment, comments = morecomments } ! []
 
         NewComment (Err error) ->
-            -- TODO display the error in the UI
-            let
-                _ =
-                    Debug.log "DEBUG: error when POSTing comment " error
-            in
-                ( model, Cmd.none )
+            model ! [ Ports.showError (getHTTPErrorMessage error) ]
 
         NewComments (Ok comments) ->
             { model | comments = comments } ! []
 
         NewComments (Err error) ->
-            let
-                errorMessage =
-                    case error of
-                        Http.NetworkError ->
-                            "Is the server running?"
-
-                        Http.BadStatus response ->
-                            (toString response.status)
-
-                        Http.BadPayload message _ ->
-                            "Decoding Failed: " ++ message
-
-                        _ ->
-                            (toString error)
-
-                _ =
-                    Debug.log "DEBUG: " errorMessage
-            in
-                ( model, Cmd.none )
+            model ! [ Ports.showError (getHTTPErrorMessage error) ]
 
         ShowError value ->
             model ! [ Ports.showError value ]

--- a/webui/src/Types.elm
+++ b/webui/src/Types.elm
@@ -26,3 +26,4 @@ type Msg
     | NewComments (Result Http.Error (List Comment.Types.Comment))
     | NewComment (Result Http.Error (List Comment.Types.Comment))
     | SetCommentMessageInput String
+    | ShowError String

--- a/webui/src/View/Home.elm
+++ b/webui/src/View/Home.elm
@@ -128,6 +128,22 @@ selectedItem model =
                 String.toLower item.text
 
 
+snackBar : Model -> Html Msg
+snackBar model =
+    div
+        [ id "error-snackbar"
+        , class "mdc-snackbar"
+        , attribute "aria-live" "assertive"
+        , attribute "aria-atomic" "true"
+        , attribute "aria-hidden" "true"
+          -- , onClick (Types.ShowError "this is an error message")
+        ]
+        [ div [ class "mdc-snackbar__text" ] []
+        , div [ class "mdc-snackbar__action-wrapper" ]
+            [ button [ class "mdc-snackbar__action-button" ] [] ]
+        ]
+
+
 body : Model -> Html Msg
 body model =
     div [ id "content" ]
@@ -149,6 +165,7 @@ body model =
 
             Just _ ->
                 notFoundBody model
+        , snackBar model
         ]
 
 
@@ -160,7 +177,15 @@ dashboardBody model =
     in
         div
             []
-            [ Centroid.view data ]
+            [ Centroid.view data
+            , br [] []
+            , button
+                [ class "mdc-button mdc-button--raised mdc-button--primary"
+                , attribute "data-mdc-auto-init" "MDCRipple"
+                , onClick (Types.ShowError "this is an error message")
+                ]
+                [ text "Show Error" ]
+            ]
 
 
 reportsBody : Model -> Html Msg
@@ -187,8 +212,6 @@ commentsForm : Model -> Html Msg
 commentsForm model =
     div
         [ id "Comments" ]
-        -- TODO wire up a handler to save the data from these inputs into
-        -- our model when they change
         [ div []
             [ div
                 [ class "mdc-textfield"

--- a/webui/src/View/Home.elm
+++ b/webui/src/View/Home.elm
@@ -180,7 +180,7 @@ dashboardBody model =
             [ Centroid.view data
             , br [] []
             , button
-                [ class "mdc-button mdc-button--raised mdc-button--primary"
+                [ class "mdc-button mdc-button--raised mdc-button--accent"
                 , attribute "data-mdc-auto-init" "MDCRipple"
                 , onClick (Types.ShowError "this is an error message")
                 ]
@@ -208,6 +208,11 @@ onValueChanged tagger =
     on "value-changed" (Json.map tagger Html.Events.targetValue)
 
 
+showDebugData : record -> Html Msg
+showDebugData record =
+    div [ class "debug" ] [ text ("DEBUG: " ++ toString record) ]
+
+
 commentsForm : Model -> Html Msg
 commentsForm model =
     div
@@ -227,12 +232,12 @@ commentsForm model =
                 ]
             ]
         , button
-            [ class "mdc-button mdc-button--raised mdc-button--primary"
+            [ class "mdc-button mdc-button--raised mdc-button--accent"
             , attribute "data-mdc-auto-init" "MDCRipple"
             , onClick (Types.AddComment model)
             ]
             [ text "Add" ]
-        , div [ class "debug" ] [ text ("DEBUG: " ++ toString model.newComment) ]
+        , showDebugData model.newComment
         ]
 
 

--- a/webui/src/index.js
+++ b/webui/src/index.js
@@ -24,6 +24,12 @@ document.arrive(".mdc-textfield", function(){
   window.mdc.autoInit(document, () => { });
 });
 
+
+elmApp.ports.showError.subscribe(function(messageString) {
+  let snack = mdc.snackbar.MDCSnackbar.attachTo(document.querySelector('.mdc-snackbar'));
+  snack.show({ message: messageString });
+});
+
 document.arrive("#MenuButton", function(){
   let drawer = new mdc.drawer.MDCPersistentDrawer(document.getElementById('MenuDrawer'));
   document.getElementById('MenuButton').addEventListener('click', function () {

--- a/webui/src/main.scss
+++ b/webui/src/main.scss
@@ -4,6 +4,7 @@ html, .container {
 
 body {
   --mdc-theme-primary:#2FA09D;
+  --mdc-theme-secondary:#E86953;
   --mdc-theme-accent:#E86953;
   --mdc-theme-background: #f0f0f1;
   background-color:var(--mdc-theme-background, #f0f0f1);
@@ -28,7 +29,7 @@ body {
 }
 
 .header{
-  background-color: var(--mdc-theme-accent) !important;
+  background-color: var(--mdc-theme-primary);
   color: var(--mdc-theme-text-primary-on-primary,#fff);
 }
 


### PR DESCRIPTION
I made some revisions to the colors based on guidance in the material design color system about when to use the primary theme color and when to use secondary. The mockups from Hiromi were using the secondary or accent color for the header, and the color system is intended so that the primary color is used for the header and the main action button can then use the secondary color or a lighter/darker version of the primary. https://material.io/guidelines/style/color.html#color-color-system. 

Aaron created this color palette for us:
![color palette](https://user-images.githubusercontent.com/983/32034038-3ebd4fd8-b9de-11e7-97a3-9aa829a8d6de.png)
We may end up wanting to do a revision of the color palette based on https://material.io/guidelines/style/color.html#color-color-palette

I think this change is more calm and confident.
<img width="806" alt="haven_grc_-_home" src="https://user-images.githubusercontent.com/983/32034181-12a9240c-b9df-11e7-8fb0-1aa3965b4ce8.png">
