### PR TITLE
Fix snackbar crash when logged out.

### DIFF
--- a/webui/src/index.js
+++ b/webui/src/index.js
@@ -26,8 +26,11 @@ document.arrive(".mdc-textfield", function(){
 
 
 elmApp.ports.showError.subscribe(function(messageString) {
-  let snack = mdc.snackbar.MDCSnackbar.attachTo(document.querySelector('.mdc-snackbar'));
-  snack.show({ message: messageString });
+  let item = document.querySelector('.mdc-snackbar');
+  if (item !== null) {
+    let snack = mdc.snackbar.MDCSnackbar.attachTo();
+    snack.show({ message: messageString });
+  }
 });
 
 document.arrive("#MenuButton", function(){


### PR DESCRIPTION
Runtime exceptions! I wish we didn't need javascript to trigger the MDC animations, but I guess thats the price we have to pay.