### PR TITLE
Authentication cleanup, token refresh, session expiry, single sign-out

### DIFF
--- a/webui/src/Authentication.elm
+++ b/webui/src/Authentication.elm
@@ -15,13 +15,13 @@ import Keycloak
 type alias Model =
     { state : Keycloak.AuthenticationState
     , lastError : Maybe Keycloak.AuthenticationError
-    , showLock : Keycloak.Options -> Cmd Msg
+    , logIn : Keycloak.Options -> Cmd Msg
     , logOut : () -> Cmd Msg
     }
 
 
 init : (Keycloak.Options -> Cmd Msg) -> (() -> Cmd Msg) -> Maybe Keycloak.LoggedInUser -> Model
-init showLock logOut initialData =
+init logIn logOut initialData =
     { state =
         case initialData of
             Just user ->
@@ -30,7 +30,7 @@ init showLock logOut initialData =
             Nothing ->
                 Keycloak.LoggedOut
     , lastError = Nothing
-    , showLock = showLock
+    , logIn = logIn
     , logOut = logOut
     }
 
@@ -57,7 +57,7 @@ update msg model =
                 ( { model | state = newState, lastError = error }, Cmd.none )
 
         ShowLogIn ->
-            ( model, model.showLock Keycloak.defaultOpts )
+            ( model, model.logIn Keycloak.defaultOpts )
 
         LogOut ->
             ( { model | state = Keycloak.LoggedOut }, model.logOut () )

--- a/webui/src/Comment/Rest.elm
+++ b/webui/src/Comment/Rest.elm
@@ -49,11 +49,7 @@ tryGetAuthHeader : Model -> List Http.Header
 tryGetAuthHeader model =
     case model.authModel.state of
         Keycloak.LoggedIn user ->
-            let
-                _ =
-                    Debug.log "user token is: " user.token
-            in
-                [ (Http.header "Authorization" ("Bearer " ++ user.token)) ]
+            [ (Http.header "Authorization" ("Bearer " ++ user.token)) ]
 
         Keycloak.LoggedOut ->
             let

--- a/webui/src/Ports.elm
+++ b/webui/src/Ports.elm
@@ -3,10 +3,10 @@ port module Ports exposing (..)
 import Keycloak exposing (Options, RawAuthenticationResult)
 
 
-port keycloakShowLock : Options -> Cmd msg
-
-
 port keycloakAuthResult : (RawAuthenticationResult -> msg) -> Sub msg
+
+
+port keycloakLogin : Options -> Cmd msg
 
 
 port keycloakLogout : () -> Cmd msg

--- a/webui/src/State.elm
+++ b/webui/src/State.elm
@@ -19,7 +19,7 @@ init initialUser location =
 
         model =
             { count = 0
-            , authModel = (Authentication.init Ports.keycloakShowLock Ports.keycloakLogout initialUser)
+            , authModel = (Authentication.init Ports.keycloakLogin Ports.keycloakLogout initialUser)
             , route = route
             , selectedTab = 0
             , comments = []

--- a/webui/src/index.js
+++ b/webui/src/index.js
@@ -18,19 +18,8 @@ var authData = storedProfile && storedToken ? { profile: JSON.parse(storedProfil
 
 var elmApp = Main.embed(document.getElementById('root'), authData);
 
-keycloak.init();
-
 document.arrive(".mdc-textfield", function(){
   window.mdc.autoInit(document, () => { });
-});
-
-
-elmApp.ports.showError.subscribe(function(messageString) {
-  let item = document.querySelector('.mdc-snackbar');
-  if (item !== null) {
-    let snack = mdc.snackbar.MDCSnackbar.attachTo();
-    snack.show({ message: messageString });
-  }
 });
 
 document.arrive("#MenuButton", function(){
@@ -44,7 +33,6 @@ document.arrive("#UserDropdownMenu", function(){
   let menu = new mdc.menu.MDCSimpleMenu(document.getElementById('UserDropdownMenu'));
   document.getElementById('UserDropdownButton').addEventListener('click', () => menu.open = !menu.open);
 });
-
 
 
 keycloak.onAuthSuccess = function() {
@@ -84,7 +72,9 @@ keycloak.onTokenExpired = function() {
   //elmApp.ports.keycloakLogoutHappened.send();
 };
 
-elmApp.ports.keycloakShowLock.subscribe(function() {
+keycloak.init();
+
+elmApp.ports.keycloakLogin.subscribe(function() {
   console.log("calling login");
   keycloak.login().error(function(/*errorData*/) {
     alert('failed to initialize'); // TODO polish this error case
@@ -103,4 +93,12 @@ elmApp.ports.keycloakLogout.subscribe(function() {
 // set the page title
 elmApp.ports.setTitle.subscribe(function(title) {
   document.title = title;
+});
+
+elmApp.ports.showError.subscribe(function(messageString) {
+  let item = document.querySelector('.mdc-snackbar');
+  if (item) {
+    let snack = mdc.snackbar.MDCSnackbar.attachTo(item);
+    snack.show({ message: messageString });
+  }
 });


### PR DESCRIPTION
This organizes and refactors some of the authentication code.

A crash was fixed with snackbar.

Keycloak has both refresh tokens and access tokens. Refresh tokens are kept by keycloak.js. Access tokens are used to send to the backend service. Refresh tokens expire quickly (5 min) and so we were being left in a state of being logged in but with an invalid token. Refresh is now hooked up to correctly exchange the token when it expires, and pass the fresh token in to the Elm model.

Refresh token activity will cause the session to appear active to keycloak, so it prevents the session timeout from being reached even when the page is idle. I need to adjust refresh token so it is only done when the user is active (perhaps only when we are about to make an API call).

The keycloak session status iframe does seem to be loading but is not triggering a logout when a session logout is performed from the keycloak admin page.