### PR TITLE
Record stable keycloak user ID in addition to email.

### DIFF
--- a/apitest/features/sqitch-jwt.feature
+++ b/apitest/features/sqitch-jwt.feature
@@ -14,9 +14,10 @@ Feature: Basic sqitch API interaction with JWT
         Then the request is successful and a comment was created
         Then the response is a list of 1 comment
         Then one item has the following attributes:
-            | attribute  | type     | value                     |
-            | user_email | string   | user1@havengrc.com        |
-            | message    | string   | The system must be tested |
+            | attribute  | type     | value                                |
+            | user_email | string   | user1@havengrc.com                   |
+            | user_id    | string   | 90920d91-3090-4b4a-ae2a-2377cfa06ecd |
+            | message    | string   | The system must be tested            |
 
 
     Scenario: Search for all comments

--- a/deploy/dev.sql
+++ b/deploy/dev.sql
@@ -36,6 +36,11 @@ BEGIN
   ELSE
     NEW.user_email = current_setting('request.jwt.claim.email', true);
   END IF;
+  IF NEW.user_id IS NOT NULL THEN
+    RAISE EXCEPTION 'You must not send the user_id field';
+  ELSE
+    NEW.user_id = current_setting('request.jwt.claim.sub', true);
+  END IF;
 
   RETURN NEW;
 END;
@@ -45,13 +50,14 @@ CREATE TABLE mappa.comment (
   uuid        UUID        UNIQUE,
   created_at  TIMESTAMPTZ,
   user_email  NAME,
+  user_id     UUID,
   message     TEXT
 );
 
 CREATE TRIGGER override_comment_cols BEFORE INSERT ON mappa.comment FOR EACH ROW EXECUTE PROCEDURE mappa.override_server_columns();
 
 CREATE OR REPLACE VIEW "1".comment as
-  SELECT uuid, user_email, created_at, message from mappa.comment;
+  SELECT uuid, user_email, user_id, created_at, message from mappa.comment;
 
 GRANT SELECT, INSERT ON mappa.comment to member;
 GRANT all ON "1".comment to member;

--- a/webui/src/Comment/Rest.elm
+++ b/webui/src/Comment/Rest.elm
@@ -10,10 +10,11 @@ import Types exposing (..)
 
 commentDecoder : Decoder Comment
 commentDecoder =
-    Decode.map4 Comment
+    Decode.map5 Comment
         (field "uuid" Decode.string)
         (field "created_at" Decode.string)
         (field "user_email" Decode.string)
+        (field "user_id" Decode.string)
         (field "message" Decode.string)
 
 

--- a/webui/src/Comment/Types.elm
+++ b/webui/src/Comment/Types.elm
@@ -5,10 +5,11 @@ type alias Comment =
     { uuid : String
     , created_at : String
     , user_email : String
+    , user_id : String
     , message : String
     }
 
 
 emptyNewComment : Comment
 emptyNewComment =
-    Comment "" "" "" ""
+    Comment "" "" "" "" ""

--- a/webui/src/View/Home.elm
+++ b/webui/src/View/Home.elm
@@ -198,7 +198,7 @@ commentsBody model =
     div []
         [ text "This is the comments view"
         , ul []
-            (List.map (\l -> li [] [ text (l.message ++ " - " ++ l.user_email ++ " posted at " ++ l.created_at) ]) model.comments)
+            (List.map (\l -> li [] [ text (l.message ++ " - " ++ l.user_email ++ "(" ++ l.user_id ++ ")" ++ " posted at " ++ l.created_at) ]) model.comments)
         , commentsForm model
         ]
 


### PR DESCRIPTION
Users can change their email addresses over time. When attributing records to a user we need to use a more stable user ID. Keycloak identifies each user with a stable uuid, and this is exposed as the sub claim in the JWT, and as the `id` in the profile. This PR adjusts the database code to store the stable user id along with the email. In the future we should probably maintain a separate uuid -> user profile table, or gather this info from the keycloak API if we end up doing graphql.