### PR TITLE
Fix havenapi images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Check docker compose version
-          command: docker-compose -v
+          name: Check docker-compose and docker version
+          command: docker-compose -v && docker -v
       - run:
           name: Build images
           command: docker-compose build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,8 @@ jobs:
               docker tag kindlyops/mappamundi kindlyops/mappamundi:$CIRCLE_SHA1
               docker tag kindlyops/havensqitch kindlyops/havensqitch:$CIRCLE_SHA1
               docker tag kindlyops/havensqitch kindlyops/havensqitch:latest
-              docker tag kindlyops/havensqitch kindlyops/havenapi:$CIRCLE_SHA1
-              docker tag kindlyops/havensqitch kindlyops/havenapi:latest
+              docker tag kindlyops/havenapi kindlyops/havenapi:$CIRCLE_SHA1
+              docker tag kindlyops/havenapi kindlyops/havenapi:latest
               docker tag kindlyops/havenweb kindlyops/havenweb:$CIRCLE_SHA1
               docker tag kindlyops/havenweb kindlyops/havenweb:latest
               docker tag kindlyops/keycloak kindlyops/keycloak:$CIRCLE_SHA1

--- a/k8s/keycloak-deployment.yaml
+++ b/k8s/keycloak-deployment.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: havenapi
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
+      labels:
+        service: havenapi
+    spec:
+      containers:
+        - name: havenapi
+          image: kindlyops/havenapi:0.0.5
+          env:
+            - name: GO_ENV
+              value: "production"
+            - name: DATABASE_HOST
+              value: "db"
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: haven-database-credentials
+                  key: username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: haven-database-credentials
+                  key: password
+            - name: HAVEN_JWK_PATH
+              value: "/etc/haven-credentials/jwk.json"
+          volumeMounts:
+            - name: secret-volume
+              mountPath: /etc/haven-credentials/
+              readOnly: true
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 1
+            periodSeconds: 5
+      volumes:
+        - name: secret-volume
+          secret:
+            secretName: haven-database-credentials
+      restartPolicy: Always
+  strategy:
+    type: "Recreate"
+  paused: false
+  revisionHistoryLimit: 2
+  minReadySeconds: 0
+status: {}

--- a/k8s/keycloak-service.yaml
+++ b/k8s/keycloak-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak      
+spec:
+  selector:                  
+    service: keycloak
+  ports:
+  - nodePort: 0
+    port: 8080               
+    protocol: TCP
+    targetPort: 8080


### PR DESCRIPTION
The build process was accidentally tagging the sqitch docker image as havenapi and then deploying the wrong thing. 