### PR TITLE
Postgrest openshift online deployment & service spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
       - run: docker build --rm=false -t kindlyops/mappamundi .
       - run: docker build --rm=false -t kindlyops/havenapi havenapi/
       - run: docker build --rm=false -t kindlyops/havensqitch sqitch/
+      - run: docker build --rm=false -t kindlyops/postgrest -f postgrest/Dockerfile .
       - run:
           name: compile Elm project
           command: npm run-script build
@@ -67,6 +68,8 @@ jobs:
               docker tag kindlyops/havenweb kindlyops/havenweb:latest
               docker tag kindlyops/keycloak kindlyops/keycloak:$CIRCLE_SHA1
               docker tag kindlyops/keycloak kindlyops/keycloak:latest
+              docker tag kindlyops/postgrest kindlyops/postgres:$CIRCLE_SHA1
+              docker tag kindlyops/postgrest kindlyops/postgres:latest
               docker push kindlyops/mappamundi:$CIRCLE_SHA1
               docker push kindlyops/havensqitch:$CIRCLE_SHA1
               docker push kindlyops/havensqitch:latest
@@ -76,6 +79,8 @@ jobs:
               docker push kindlyops/havenweb:latest
               docker push kindlyops/keycloak:$CIRCLE_SHA1
               docker push kindlyops/keycloak:latest
+              docker push kindlyops/postgrest:$CIRCLE_SHA1
+              docker push kindlyops/postgrest:latest
               oc set image deployment/havenapi havenapi=havengrc-docker.jfrog.io/kindlyops/havenapi:$CIRCLE_SHA1
               oc set image deployment/havenweb havenweb=havengrc-docker.jfrog.io/kindlyops/havenweb:$CIRCLE_SHA1
             else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,18 +72,26 @@ services:
     environment:
       - endpoint=http://api/
   api:
-    image: havengrc-docker.jfrog.io/postgrest/postgrest:v0.4.3.0
+    build:
+      dockerfile: ./postgrest/Dockerfile
+      context: .
     command: [postgrest, "/config"]
+    environment:
+      - DATABASE_NAME=mappamundi_dev
+      - DATABASE_USERNAME=postgres
+      - DATABASE_PASSWORD=postgres
+      - DATABASE_HOST=db
+      - HAVEN_JWK_PATH=/keycloak-dev-public-key.json
+      - PGRST_JWT_AUD_CLAIM=havendev
+      - PGRST_SERVER_PROXY_URI=http://localhost:8180
+    volumes:
+      - ./postgrest/keycloak-dev-public-key.json:/keycloak-dev-public-key.json
     ports:
-      - "3001:80"
+      - "3001:8180"
     links:
       - db
     depends_on:
       - sqitch
-    volumes:
-      - ./postgrest/config:/config
-      - ./postgrest/keycloak-dev-public-key.json:/keycloak-dev-public-key.json
-      - ./postgrest/vendor/postgrest:/usr/local/bin/postgrest
   swagger:
     image: havengrc-docker.jfrog.io/swaggerapi/swagger-ui:v3.0.2
     ports:

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: havengrc-docker.jfrog.io/postgrest/postgrest:latest
+          image: havengrc-docker.jfrog.io/kindlyops/postgrest:latest
           env:
             - name: DATABASE_HOST
               value: "db"
@@ -33,15 +33,11 @@ spec:
             - name: PGRST_JWT_AUD
               value: "havendev"
             - name: PGRST_JWT_SECRET
-              value: "@/etc/haven-credentials/jwk.json"
+              value: "/haven-credentials/jwk.json"
             - name: PGRST_SERVER_PORT
               value: "8180"
             - name: PGRST_SERVER_PROXY_URI
               value: "https://staging.havengrc.com/api"
-            - name: PGRST_DB_POOL
-              value: "10"
-            - name: PGRST_DB_URI
-              value: "postgres://$DATABASE_USERNAME:$DATABASE_PASSWORD@db/havenstage"
           volumeMounts:
             - name: secret-volume
               mountPath: /etc/haven-credentials/

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -15,9 +15,33 @@ spec:
       containers:
         - name: api
           image: havengrc-docker.jfrog.io/postgrest/postgrest:latest
-          args:
-            - postgrest
-            - /config
+          env:
+            - name: PGRST_DB_URI
+              value: "postgres://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@db/havenstage"
+            - name: DATABASE_HOST
+              value: "db"
+            - name: PGRST_DB_SCHEMA
+              value: "1"
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: haven-database-credentials
+                  key: username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: haven-database-credentials
+                  key: password
+            - name: PGRST_JWT_AUD
+              value: "havendev"
+            - name: PGRST_JWT_SECRET
+              value: "@/etc/haven-credentials/jwk.json"
+            - name: PGRST_SERVER_PORT
+              value: "80"
+            - name: PGRST_SERVER_PROXY_URI
+              value: "https://staging.havengrc.com/api"
+            - name: PGRST_DB_POOL
+              value: "10"
           volumeMounts:
             - name: secret-volume
               mountPath: /etc/haven-credentials/

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -15,9 +15,14 @@ spec:
       containers:
         - name: api
           image: havengrc-docker.jfrog.io/kindlyops/postgrest:latest
+          args:
+          - postgrest
+          - /config
           env:
             - name: DATABASE_HOST
               value: "db"
+            - name: DATABASE_NAME
+              value: "havenstage"
             - name: PGRST_DB_SCHEMA
               value: "1"
             - name: DATABASE_USERNAME
@@ -30,6 +35,8 @@ spec:
                 secretKeyRef:
                   name: haven-database-credentials
                   key: password
+            - name: HAVEN_JWK_PATH
+              value: "/etc/haven-credentials/jwk.json"
             - name: PGRST_JWT_AUD
               value: "havendev"
             - name: PGRST_JWT_SECRET

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -22,12 +22,6 @@ spec:
             - name: secret-volume
               mountPath: /etc/haven-credentials/
               readOnly: true
-            - mountPath: /config
-              name: api-claim0
-            - mountPath: /keycloak-dev-public-key.json
-              name: api-claim1
-            - mountPath: /usr/local/bin/postgrest
-              name: api-claim2
           ports:
             - containerPort: 3001
               protocol: TCP
@@ -36,15 +30,6 @@ spec:
         - name: secret-volume
           secret:
             secretName: haven-database-credentials
-        - name: api-claim0
-          persistentVolumeClaim:
-            claimName: api-claim0
-        - name: api-claim1
-          persistentVolumeClaim:
-            claimName: api-claim1
-        - name: api-claim2
-          persistentVolumeClaim:
-            claimName: api-claim2
       restartPolicy: Always
   strategy:
     type: "Recreate"

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -16,8 +16,6 @@ spec:
         - name: api
           image: havengrc-docker.jfrog.io/postgrest/postgrest:latest
           env:
-            - name: PGRST_DB_URI
-              value: "postgres://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@db/havenstage"
             - name: DATABASE_HOST
               value: "db"
             - name: PGRST_DB_SCHEMA
@@ -37,11 +35,13 @@ spec:
             - name: PGRST_JWT_SECRET
               value: "@/etc/haven-credentials/jwk.json"
             - name: PGRST_SERVER_PORT
-              value: "80"
+              value: "8180"
             - name: PGRST_SERVER_PROXY_URI
               value: "https://staging.havengrc.com/api"
             - name: PGRST_DB_POOL
               value: "10"
+            - name: PGRST_DB_URI
+              value: "postgres://$DATABASE_USERNAME:$DATABASE_PASSWORD@db/havenstage"
           volumeMounts:
             - name: secret-volume
               mountPath: /etc/haven-credentials/
@@ -49,7 +49,7 @@ spec:
           ports:
             - containerPort: 3001
               protocol: TCP
-              targetPort: 80
+              targetPort: 8180
       volumes:
         - name: secret-volume
           secret:

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
+      labels:
+        service: api
+    spec:
+      containers:
+        - name: api
+          image: havengrc-docker.jfrog.io/postgrest/postgrest:latest
+          args:
+            - postgrest
+            - /config
+          volumeMounts:
+            - name: secret-volume
+              mountPath: /etc/haven-credentials/
+              readOnly: true
+            - mountPath: /config
+              name: api-claim0
+            - mountPath: /keycloak-dev-public-key.json
+              name: api-claim1
+            - mountPath: /usr/local/bin/postgrest
+              name: api-claim2
+          ports:
+            - containerPort: 3001
+              protocol: TCP
+              targetPort: 80
+      volumes:
+        - name: secret-volume
+          secret:
+            secretName: haven-database-credentials
+        - name: api-claim0
+          persistentVolumeClaim:
+            claimName: api-claim0
+        - name: api-claim1
+          persistentVolumeClaim:
+            claimName: api-claim1
+        - name: api-claim2
+          persistentVolumeClaim:
+            claimName: api-claim2
+      restartPolicy: Always
+  strategy:
+    type: "Recreate"
+  paused: false
+  revisionHistoryLimit: 2
+  minReadySeconds: 0
+status: {}

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+spec:
+  selector:
+    service: api
+  ports:
+  - nodePort: 0
+    port: 3001
+    protocol: TCP
+    targetPort: 80

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -9,4 +9,4 @@ spec:
   - nodePort: 0
     port: 3001
     protocol: TCP
-    targetPort: 80
+    targetPort: 8180

--- a/postgrest/Dockerfile
+++ b/postgrest/Dockerfile
@@ -1,0 +1,23 @@
+FROM        havengrc-docker.jfrog.io/postgrest/postgrest:v0.4.3.0
+MAINTAINER  Kindly Ops, LLC <support@kindlyops.com>
+COPY        postgrest/config /config
+COPY        postgrest/vendor/postgrest /usr/local/bin/postgrest
+USER root
+RUN addgroup --system havenuser && adduser --system havenuser && adduser havenuser havenuser
+RUN chown -R havenuser:0 /config && \
+    chmod -R g+rw /config && \
+    chown -R havenuser:0 /usr/local/bin/postgrest && \
+		chmod -R g+rw /usr/local/bin/postgrest && \
+		chown -R havenuser:0 /tmp && \
+		chmod -R g+rw /tmp
+USER 1000
+ENV         ENV_VERBOSITY 无
+ENV         DATABASE_NAME mappamundi_dev
+ENV         DATABASE_USERNAME postgres
+ENV         DATABASE_PASSWORD postgres
+ENV         DATABASE_HOST postgres
+ENV         HAVEN_JWK_PATH /keycloak-dev-public-key.json
+ENV         PGRST_JWT_AUD_CLAIM havendev
+ENV         PGRST_SERVER_PROXY_URI http://localhost:8180
+EXPOSE 8180
+CMD [postgrest, "/config"]

--- a/postgrest/config
+++ b/postgrest/config
@@ -1,4 +1,4 @@
-db-uri = "postgres://postgres@db/mappamundi_dev"
+db-uri = "postgres://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST)/$(DATABASE_NAME)"
 db-schema = "1"
 # in dev, the swagger UI introspects without providing auth.
 # Because postgrest uses the role of the user when determining
@@ -9,20 +9,19 @@ db-schema = "1"
 # a possible way to handle this would be to embed the swagger viewing inside
 # our webapp and find a way to give the swagger requests the JWT from the logged
 # in user rather than being anonymous.
-# db-anon-role = "anonymous"
-db-anon-role = "postgres"
+db-anon-role = "anonymous"
 db-pool = 10
 
 server-host = "*4"
-server-port = 80
-server-proxy-uri = "http://localhost:3001"
+server-port = 8180
+server-proxy-uri = "$(PGRST_SERVER_PROXY_URI)"
 
 ## choose a secret to enable JWT auth
 ## (use "@filename" to load from separate file)
 ## The contents of the key file for keycloak were retrieved from keycloak using:
 ## curl http://localhost:8080/auth/realms/havendev/protocol/openid-connect/certs | jq '.'
-jwt-secret = "@/keycloak-dev-public-key.json"
-jwt-aud = "havendev"
+jwt-secret = "@$(HAVEN_JWK_PATH)"
+jwt-aud = "$(PGRST_JWT_AUD_CLAIM)"
 
 # secret-is-base64 = false
 


### PR DESCRIPTION
These are the spec files required for deployment to OpenShift Online. The docker image has moved from upstream postgrest to kindlyops registry because of Audience claim code that is not in master upstream yet. 

`postgrest/dockerfile` provides defaults for the postgrest config and `api-deployment.yaml` overrides most of those. 