### PR TITLE
Adjust the Caddy proxy backend api port to match production.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,8 @@ jobs:
               docker tag kindlyops/havenweb kindlyops/havenweb:latest
               docker tag kindlyops/keycloak kindlyops/keycloak:$CIRCLE_SHA1
               docker tag kindlyops/keycloak kindlyops/keycloak:latest
-              docker tag kindlyops/postgrest kindlyops/postgres:$CIRCLE_SHA1
-              docker tag kindlyops/postgrest kindlyops/postgres:latest
+              docker tag kindlyops/postgrest kindlyops/postgrest:$CIRCLE_SHA1
+              docker tag kindlyops/postgrest kindlyops/postgrest:latest
               docker push kindlyops/mappamundi:$CIRCLE_SHA1
               docker push kindlyops/havensqitch:$CIRCLE_SHA1
               docker push kindlyops/havensqitch:latest

--- a/webui/Caddyfile
+++ b/webui/Caddyfile
@@ -11,7 +11,7 @@ proxy /auth keycloak:8080 {
   transparent
 }
 
-proxy /api api:80 {
+proxy /api api:3001 {
   without /api
   transparent
 }


### PR DESCRIPTION
This adjusts the proxy settings to match the way we have the api service configured in production.