### PR TITLE
Example org changes

### DIFF
--- a/chargebee-provider/.gitignore
+++ b/chargebee-provider/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+out/
+target/
+*.iml
+.DS_Store

--- a/chargebee-provider/pom.xml
+++ b/chargebee-provider/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+
+    <name>ChargeBee Registration</name>
+    <description/>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.kindlyops.providers</groupId>
+    <artifactId>kindlyops-provider-chargebee-registration</artifactId>
+    <version>0.1.0</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <version>2.1.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+            <version>2.1.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.3.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-services</artifactId>
+            <version>2.1.0.Final</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>kindlyops-chargebee-form-action</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                    </excludes>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+
+    </build>
+</project>

--- a/chargebee-provider/src/main/java/org/kindlyops/providers/chargebee/ChargeBeeRegistration.java
+++ b/chargebee-provider/src/main/java/org/kindlyops/providers/chargebee/ChargeBeeRegistration.java
@@ -1,0 +1,112 @@
+package org.kindlyops.providers.chargebee;
+
+import org.apache.commons.lang.StringUtils;
+import org.keycloak.Config.Scope;
+import org.keycloak.authentication.FormAction;
+import org.keycloak.authentication.FormActionFactory;
+import org.keycloak.authentication.FormContext;
+import org.keycloak.authentication.ValidationContext;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.AuthenticationExecutionModel.Requirement;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChargeBeeRegistration implements FormAction, FormActionFactory {
+    private static String FIELD_ORGANIZATION = "user.attributes.organization";
+    private static String ATTRIBUTE_ORGANIZATION = "organization";
+    private static Requirement[] REQUIREMENT_CHOICES;
+
+    public ChargeBeeRegistration() {
+
+    }
+
+    public String getDisplayType() {
+        return "ChargeBee Integration";
+    }
+
+    public String getReferenceCategory() {
+        return null;
+    }
+
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    public Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+    }
+
+    public String getId() {
+        return "chargebee-registration";
+    }
+
+    public void buildPage(FormContext context, LoginFormsProvider form) {
+    }
+
+    public void validate(ValidationContext context) {
+        MultivaluedMap formData = context.getHttpRequest().getDecodedFormParameters();
+        ArrayList errors = new ArrayList();
+        // Check for users with the organization already.
+        // TODO should be smarter than this.
+        List users = context.getSession().users().searchForUserByUserAttribute(ATTRIBUTE_ORGANIZATION,FIELD_ORGANIZATION, context.getRealm());
+        if (users.size() > 0) {
+            context.validationError(formData, errors);
+        } else {
+            context.success();
+        }
+    }
+
+    public void success(FormContext context) {
+
+        UserModel user = context.getUser();
+        MultivaluedMap formData = context.getHttpRequest().getDecodedFormParameters();
+        String org = formData.getFirst(FIELD_ORGANIZATION).toString();
+
+        if (!StringUtils.isBlank(org)) {
+            user.setSingleAttribute("organization", org);
+        }
+    }
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return null;
+    }
+
+    public boolean requiresUser() {
+        return false;
+    }
+
+    public void close() {
+    }
+
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    public String getHelpText() {
+        return "ChargeBee Registration";
+    }
+
+    public FormAction create(KeycloakSession session) {
+        return this;
+    }
+
+    public void init(Scope config) {
+    }
+
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+}

--- a/chargebee-provider/src/main/resources/META-INF/MANIFEST.MF
+++ b/chargebee-provider/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,18 @@
+Manifest-Version: 1.0
+Class-Path: commons-io-2.1.jar commons-lang-2.6.jar istack-commons-run
+ time-2.16.jar apache-mime4j-0.6.jar jboss-servlet-api_3.0_spec-1.0.2.
+ Final.jar jackson-annotations-2.5.4.jar keycloak-core-2.1.0.Final.jar
+  twitter4j-core-4.0.4.jar activation-1.1.1.jar jaxb-api-2.2.7.jar htt
+ pclient-4.3.6.jar jackson-core-2.5.4.jar jcip-annotations-1.0.jar res
+ teasy-jaxb-provider-3.0.14.Final.jar jaxb-core-2.2.7.jar resteasy-mul
+ tipart-provider-3.0.14.Final.jar jcommander-1.48.jar resteasy-client-
+ 3.0.14.Final.jar javase-3.2.1.jar FastInfoset-1.2.12.jar commons-code
+ c-1.6.jar bcpkix-jdk15on-1.52.jar commons-logging-1.1.3.jar bcprov-jd
+ k15on-1.52.jar jboss-logging-3.3.0.Final.jar core-3.2.1.jar jackson-d
+ atabind-2.5.4.jar keycloak-services-2.1.0.Final.jar keycloak-server-s
+ pi-2.1.0.Final.jar jaxb-impl-2.2.7.jar httpcore-4.3.3.jar jsr173_api-
+ 1.0.jar resteasy-jaxrs-3.0.14.Final.jar keycloak-common-2.1.0.Final.j
+ ar jboss-jaxrs-api_2.0_spec-1.0.0.Final.jar javax.mail-api-1.5.5.jar 
+ mail-1.5.0-b01.jar jboss-annotations-api_1.2_spec-1.0.0.Final.jar
+Main-Class: 
+

--- a/chargebee-provider/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
+++ b/chargebee-provider/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
@@ -1,0 +1,1 @@
+org.kindlyops.providers.chargebee.ChargeBeeRegistration

--- a/keycloak/themes/haven/account/account.ftl
+++ b/keycloak/themes/haven/account/account.ftl
@@ -32,6 +32,13 @@
                     </div>
                 </div>
 
+                <div class="${messagesPerField.printIfExists('organization','has-error')}">
+                    <div class="mdc-textfield" data-mdc-auto-init="MDCTextfield">
+                        <input type="text" class="mdc-textfield__input" id="user.attributes.organization" name="user.attributes.organization" value="${(account.attributes.organization!'')}" required/>
+                        <label for="user.attributes.organization" class="mdc-textfield__label">${msg("organization")}</label>
+                    </div>
+                </div>
+
                 <div class="${messagesPerField.printIfExists('firstName','has-error')}">
                     <div class="mdc-textfield" data-mdc-auto-init="MDCTextfield">
                         <input type="text" class="mdc-textfield__input" id="firstName" name="firstName" value="${(account.firstName!'')}" required/>

--- a/keycloak/themes/haven/login/register.ftl
+++ b/keycloak/themes/haven/login/register.ftl
@@ -32,6 +32,12 @@
            </div>
            <div>
             <div class="mdc-textfield" data-mdc-auto-init="MDCTextfield">
+                    <input type="text" id="user.attributes.organization" class="mdc-textfield__input" name="user.attributes.organization" value="${(register.formData.organization!'')}" required />
+                    <label for="user.attributes.organization" class="mdc-textfield__label">${msg("organization")}</label>
+            </div>
+           </div>
+           <div>
+            <div class="mdc-textfield" data-mdc-auto-init="MDCTextfield">
                     <input type="text" id="email" class="mdc-textfield__input" name="email" value="${(register.formData.email!'')}" required />
                     <label for="email" class="mdc-textfield__label">${msg("email")}</label>
             </div>


### PR DESCRIPTION
Hi @statik 

This adds the organization to the registration page and also the account page. Along with the base of the provider that will handle organizational verification and assignment to a new chargebee customer id. 

**TODO** 
Right now you need to manually add the `organization` attribute to the parent group or directly to a user for testing.

Perhaps we should rename the chargebee-provider to something more like organization-management-provider since we could possibly handle other tasks involved with organization creation/modification.

I assume we want to handle group creation here if it passes verification? Thoughts on this?