### PR TITLE
Add utilities for getting and decoding JWT tokens.

### DIFF
--- a/dump-token
+++ b/dump-token
@@ -1,0 +1,4 @@
+#!/bin/bash
+TOKEN=`./get-token`
+IFS=. read header payload signature <<<"${TOKEN}"
+echo -n $payload|base64 -d -i| jq .

--- a/get-token
+++ b/get-token
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USERNAME=${1:-user1@havengrc.com}
+PASSWORD=${2:-password}
+SERVER=${3:-http://localhost:2015/auth/realms/havendev/protocol/openid-connect/token}
+curl -s --data "grant_type=password&client_id=havendev&scope=openid&username=$USERNAME&password=$PASSWORD" $SERVER| jq -r '.access_token'


### PR DESCRIPTION
This adds two command line utilities that make it easy to grab a JWT token for use with curl and to decode and pretty-print the payload of claims contained in a JWT token. This should make it easier to interactively work with keycloak as we set custom attributes etc.