### PR TITLE
Build and install our custom keycloak SPI

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,7 +1,19 @@
-FROM        havengrc-docker.jfrog.io/jboss/keycloak:3.4.2.Final
-MAINTAINER  Kindly Ops, LLC <support@kindlyops.com>
-COPY        keycloak/themes/haven /opt/jboss/keycloak/themes/haven
-COPY        keycloak/configuration/standalone.xml /opt/jboss/keycloak/standalone/configuration/standalone.xml
+FROM maven:3.5-jdk-8 as build
+
+# be smart about layer caching. do dependency resolution from pom.xml in a layer
+# before the source code layer, so that mvn doesn't re-download when only source
+# code changes during development
+COPY chargebee-provider/pom.xml /chargebee-provider/pom.xml
+RUN mvn -f /chargebee-provider/pom.xml dependency:resolve
+# now copy the rest of the source code in a later layer
+COPY chargebee-provider /chargebee-provider
+RUN mvn -f /chargebee-provider/pom.xml clean package
+
+FROM                havengrc-docker.jfrog.io/jboss/keycloak:3.4.2.Final
+MAINTAINER          Kindly Ops, LLC <support@kindlyops.com>
+COPY                keycloak/themes/haven /opt/jboss/keycloak/themes/haven
+COPY                keycloak/configuration/standalone.xml /opt/jboss/keycloak/standalone/configuration/standalone.xml
+COPY --from=build   /chargebee-provider/target/kindlyops-chargebee-form-action.jar /opt/jboss/keycloak/standalone/deployments
 USER root
 RUN chown -R jboss:0 $JBOSS_HOME/standalone && \
     chmod -R g+rw $JBOSS_HOME/standalone && \


### PR DESCRIPTION
This incorporates the custom keycloak SPI into the docker build process.

I've been doing

    $ alias dc='docker-compose'
    $ dc build keycloak && dc up keycloak

Then I can CTRL-C and re-run after changing source code.