### PR TITLE
Add email address to user2 profile in dev.

### DIFF
--- a/keycloak/data/havendev-realm.json
+++ b/keycloak/data/havendev-realm.json
@@ -2036,6 +2036,7 @@
     "id" : "e1aca775-ef02-4c35-a141-563d40233096",
     "createdTimestamp" : 1492023568019,
     "username" : "user2@havengrc.com",
+    "email" : "user2@havengrc.com",
     "enabled" : true,
     "totp" : false,
     "emailVerified" : false,


### PR DESCRIPTION
This makes it so that both user1 and user2 in the dev setup have email addresses on their user profile.
We will need to revisit the user signup flow and what attributes we want to guarantee in keycloak, but for now this puts user2 in a usable state when doing a fresh setup.