### PR TITLE
Fix caddy syntax to work with newer version.

### DIFF
--- a/webui/Caddyfile-dev
+++ b/webui/Caddyfile-dev
@@ -1,5 +1,5 @@
 0.0.0.0:2016 
-startup npm run-script start &
+on startup npm run-script start &
 
 proxy / localhost:2015 {
   transparent


### PR DESCRIPTION
# Description

Newer caddy releases use a different syntax for event handling, update to work with the newer version of caddy that we are using.
