### PR TITLE
Grab a newer point release of flyway.

### DIFF
--- a/flyway/Dockerfile
+++ b/flyway/Dockerfile
@@ -1,4 +1,4 @@
-FROM        havengrc-docker.jfrog.io/boxfuse/flyway:5.0.3-alpine
+FROM        havengrc-docker.jfrog.io/boxfuse/flyway:5.0.7-alpine
 MAINTAINER  Kindly Ops, LLC <support@kindlyops.com>
 RUN addgroup -S havenuser && adduser -S -g havenuser havenuser
 RUN apk add --no-cache postgresql-client


### PR DESCRIPTION
# Description

While investigating the errors I was getting running flyway, I noticed there have been several point releases. Update to use the current stable release.