### PR TITLE
Remove the manual approval before deploys.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,17 +194,10 @@ workflows:
             - keycloak-build-job
             - havenapi-build-job
             - postgrest-build-job
-      - approve-deploy:
-          type: approval
+      - deploy-staging:
           requires:
             - havenapi-testing-job
             - webui-build-job
-          filters:
-            branches:
-              only: master
-      - deploy-staging:
-          requires:
-            - approve-deploy
           filters:
             branches:
               only: master


### PR DESCRIPTION
# Description

Remove manual approval step in CircleCI to streamline deploys.

I like manual approval but without getting prompted in slack it's frustrating to realize the deploy is waiting for approval.