### PR TITLE
Keycloak upgrade

### DIFF
--- a/chargebee-provider/pom.xml
+++ b/chargebee-provider/pom.xml
@@ -9,7 +9,7 @@
     <version>0.1.0</version>
     <packaging>jar</packaging>
     <properties>
-        <keycloak.version>3.4.3.Final</keycloak.version>
+        <keycloak.version>4.0.0.Final</keycloak.version>
     </properties>
     <dependencies>
         <dependency>

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -9,7 +9,7 @@ RUN mvn -f /chargebee-provider/pom.xml dependency:resolve
 COPY chargebee-provider /chargebee-provider
 RUN mvn -f /chargebee-provider/pom.xml clean package
 
-FROM                havengrc-docker.jfrog.io/jboss/keycloak:3.4.3.Final
+FROM                havengrc-docker.jfrog.io/jboss/keycloak:4.0.0.Final
 MAINTAINER          Kindly Ops, LLC <support@kindlyops.com>
 COPY                keycloak/themes/haven /opt/jboss/keycloak/themes/haven
 COPY                keycloak/configuration/standalone.xml /opt/jboss/keycloak/standalone/configuration/standalone.xml


### PR DESCRIPTION
# Description

This upgrades keycloak to 4.0 and updates the chargebee provider to compile with keycloak 4.0.

In addition to the new features, this upgrades the jackson dependencies which closes out some vulnerabilities reported via snyk.

Tested against a 3.4.3 database and upgrade did not require any intervention. 