### PR TITLE
Trying to fix keycloak using H2 instead of postgres in prod

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -16,12 +16,13 @@ COPY                keycloak/configuration/standalone.xml /opt/jboss/keycloak/st
 COPY --from=build   /chargebee-provider/target/kindlyops-chargebee-form-action.jar /opt/jboss/keycloak/standalone/deployments
 USER root
 RUN chown -R jboss:0 $JBOSS_HOME/standalone && \
-    chmod -R g+rw $JBOSS_HOME/standalone && \
-    chown -R jboss:0 $JBOSS_HOME/modules/system/layers/base && \
-		chmod -R g+rw $JBOSS_HOME/modules/system/layers/base && \
-		chown -R jboss:0 /tmp && \
-		chmod -R g+rw /tmp
+	chmod -R g+rw $JBOSS_HOME/standalone && \
+	chown -R jboss:0 $JBOSS_HOME/modules/system/layers/base && \
+	chmod -R g+rw $JBOSS_HOME/modules/system/layers/base && \
+	chown -R jboss:0 /tmp && \
+	chmod -R g+rw /tmp
 USER 1000
+ENV         DB_VENDOR postgres
 ENV         ENV_VERBOSITY 无
 ENV         POSTGRES_DATABASE mappamundi_dev
 ENV         POSTGRES_USER postgres


### PR DESCRIPTION
in staging keycloak login is broken, there is no havendev realm.

looking at the logs, it seems like the keycloak container is using H2 instead of connecting to postgres. this change seems like it might help connect to postgres.