### PR TITLE
Revert "update to postgrest 5"

### DIFF
--- a/postgrest/Dockerfile
+++ b/postgrest/Dockerfile
@@ -1,15 +1,15 @@
 FROM        havengrc-docker.jfrog.io/postgrest/postgrest:v0.4.3.0
 MAINTAINER  Kindly Ops, LLC <support@kindlyops.com>
 COPY        postgrest/config /config
-#COPY        postgrest/vendor/postgrest /usr/local/bin/postgrest
+COPY        postgrest/vendor/postgrest /usr/local/bin/postgrest
 USER root
 RUN addgroup --system havenuser && adduser --system havenuser && adduser havenuser havenuser
 RUN chown -R havenuser:0 /config && \
-	chmod -R g+rw /config && \
-	chown -R havenuser:0 /usr/local/bin/postgrest && \
-	chmod -R g+rw /usr/local/bin/postgrest && \
-	chown -R havenuser:0 /tmp && \
-	chmod -R g+rw /tmp
+    chmod -R g+rw /config && \
+    chown -R havenuser:0 /usr/local/bin/postgrest && \
+		chmod -R g+rw /usr/local/bin/postgrest && \
+		chown -R havenuser:0 /tmp && \
+		chmod -R g+rw /tmp
 USER 1000
 ENV         ENV_VERBOSITY 无
 ENV         DATABASE_NAME mappamundi_dev


### PR DESCRIPTION
# Description
The new version Postgrest was failing the jwt validation so we are reverting commit 461b57edf2156645d4bbb769191877db5772ced2. 

We will have to investigate further as to why exactly it is failing but this should correct the issues we were seeing.