### PR TITLE
Switch to the keycloak-openshift base image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
             docker cp postgrest/keycloak-dev-public-key.json configs:/cfg
             docker cp keycloak/data/havendev-realm.json configs:/keycloak
             # start keycloak in background container
-            docker run --volumes-from configs --network container:db -d -e DB_DATABASE -e DB_USER -e DB_ADDR -e KEYCLOAK_USER -e KEYCLOAK_PASSWORD -e PROXY_ADDRESS_FORWARDING --name keycloak kindlyops/keycloak:$CIRCLE_SHA1 -b 0.0.0.0 -Dkeycloak.migration.file=/keycloak/havendev-realm.json -Dkeycloak.migration.strategy=IGNORE_EXISTING -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.action=import
+            docker run --volumes-from configs --network container:db -d -e DB_DATABASE -e DB_USER -e DB_ADDR -e KEYCLOAK_USER -e KEYCLOAK_PASSWORD -e PROXY_ADDRESS_FORWARDING --name keycloak kindlyops/keycloak:$CIRCLE_SHA1 start-keycloak.sh -b 0.0.0.0 -Dkeycloak.migration.file=/keycloak/havendev-realm.json -Dkeycloak.migration.strategy=IGNORE_EXISTING -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.action=import
             # Wait for keycloak
             docker run --network container:db jwilder/dockerize  -wait tcp://localhost:8080 -timeout 2m
             docker run --network container:db -e FLYWAY_URL -e FLYWAY_USER -e FLYWAY_IGNORE_MISSING_MIGRATIONS -e FLYWAY_GROUP -e FLYWAY_SCHEMAS kindlyops/havenflyway:$CIRCLE_SHA1 migrate -placeholders.databaseUser=circleci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     volumes:
       - ./keycloak/themes/haven:/opt/jboss/keycloak/themes/haven
       - ./keycloak/data:/keycloak
-    command: ["-b", "0.0.0.0", "-Dkeycloak.migration.file=/keycloak/havendev-realm.json", "-Dkeycloak.migration.strategy=IGNORE_EXISTING", "-Dkeycloak.migration.provider=singleFile", "-Dkeycloak.migration.action=import"]
+    command: ["start-keycloak.sh", "-b", "0.0.0.0", "-Dkeycloak.migration.file=/keycloak/havendev-realm.json", "-Dkeycloak.migration.strategy=IGNORE_EXISTING", "-Dkeycloak.migration.provider=singleFile", "-Dkeycloak.migration.action=import"]
   flyway:
     build:
       context: flyway/

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -9,19 +9,12 @@ RUN mvn -f /keycloak-service-providers/pom.xml dependency:resolve
 COPY keycloak-service-providers /keycloak-service-providers
 RUN mvn -f /keycloak-service-providers/pom.xml clean package
 
-FROM                havengrc-docker.jfrog.io/jboss/keycloak:4.0.0.Final
+FROM                havengrc-docker.jfrog.io/jboss/keycloak-openshift:4.0.0.Final
 MAINTAINER          Kindly Ops, LLC <support@kindlyops.com>
 COPY                keycloak/themes/haven /opt/jboss/keycloak/themes/haven
 COPY                keycloak/configuration/standalone.xml /opt/jboss/keycloak/standalone/configuration/standalone.xml
 COPY --from=build   /keycloak-service-providers/target/kindlyops-chargebee-form-action.jar /opt/jboss/keycloak/standalone/deployments
-USER root
-RUN chown -R jboss:0 $JBOSS_HOME/standalone && \
-	chmod -R g+rw $JBOSS_HOME/standalone && \
-	chown -R jboss:0 $JBOSS_HOME/modules/system/layers/base && \
-	chmod -R g+rw $JBOSS_HOME/modules/system/layers/base && \
-	chown -R jboss:0 /tmp && \
-	chmod -R g+rw /tmp
-USER 1000
+
 ENV         DB_VENDOR postgres
 ENV         ENV_VERBOSITY 无
 ENV         DB_DATABASE mappamundi_dev
@@ -34,4 +27,4 @@ ENV         PROXY_ADDRESS_FORWARDING true
 ENV         KEYCLOAK_LOGLEVEL DEBUG
 EXPOSE 8443
 EXPOSE 8080
-CMD         ["-b", "0.0.0.0"]
+CMD         ["start-keycloak.sh", "-b", "0.0.0.0"]


### PR DESCRIPTION
Some of the permissions tweaks are already included in this
upstream image, simplifies our Dockerfile and also makes
it easier for my bazel experiments.

Need to test in staging to confirm this image runs ok in the openshift environment. Works fine in local dev under docker-compose.