### PR TITLE
Refactor to grant anonymous read only for likert.

### DIFF
--- a/apitest/features/sqitch-jwt.feature
+++ b/apitest/features/sqitch-jwt.feature
@@ -5,6 +5,7 @@ Feature: Basic sqitch API interaction with JWT
         And I sign in to keycloak with "user1@havengrc.com" and "password"
         And I add Headers:
             | Prefer | return=representation             |
+        And I wait for 2 seconds
 
 
     Scenario: Add/update a comment without ability to spoof the user_email

--- a/apitest/features/sqitch-nojwt.feature
+++ b/apitest/features/sqitch-nojwt.feature
@@ -1,10 +1,9 @@
-Feature: Basic sqitch access control 
+Feature: Basic sqitch access control
 
     Background: Setup environment without JWT Auth
         Given I send and accept JSON
         And I add Headers:
             | Prefer | return=representation |
-        
 
     Scenario: Add/update a comment without a JWT to see access denied
         When I set JSON request body to:
@@ -14,4 +13,28 @@ Feature: Basic sqitch access control
         }
         """
         And  I send a POST request to "http://{api_server}/comments"
+        Then the response status should be "401"
+
+    Scenario: Get likert questions
+        When I send a GET request to "http://{api_server}/likert_questions"
+        Then the response status should be "200"
+        And the JSON response root should be array
+
+    Scenario: Delete likert questions
+        When I send a DELETE request to "http://{api_server}/likert_questions"
+        Then the response status should be "401"
+
+    Scenario: Add/update a question without a JWT to see access denied
+        When I set JSON request body to:
+        """
+	{
+	"uuid":"fakeuuid",
+	"created_at":"2018-07-31T16:24:51.152842+00:00",
+	"survey_id":"somesurveyID",
+	"choice_group_id":"somegroupid",
+	"order_number":3,
+	"title":"newgroup"
+	}
+        """
+        And  I send a POST request to "http://{api_server}/likert_questions"
         Then the response status should be "401"

--- a/apitest/features/sqitch-nojwt.feature
+++ b/apitest/features/sqitch-nojwt.feature
@@ -19,6 +19,7 @@ Feature: Basic sqitch access control
         When I send a GET request to "http://{api_server}/likert_questions"
         Then the response status should be "200"
         And the JSON response root should be array
+	And the JSON response should have "$[0].title" of type string and value "Security Value of Failure"
 
     Scenario: Delete likert questions
         When I send a DELETE request to "http://{api_server}/likert_questions"

--- a/apitest/features/step_definitions/steps.rb
+++ b/apitest/features/step_definitions/steps.rb
@@ -17,3 +17,7 @@ Given(/^I sign in to keycloak with "([^"]*)" and "([^"]*)"$/) do |username, pass
   @headers = {} if @headers.nil?
   @headers['Authorization'] = "Bearer #{access_token}"
 end
+
+Given /^I wait for (\d+) seconds?$/ do |n|
+  sleep(n.to_i)
+end

--- a/flyway/sql/V15__likert_questions.sql
+++ b/flyway/sql/V15__likert_questions.sql
@@ -1,0 +1,3 @@
+GRANT USAGE ON SCHEMA "1" TO anonymous;
+GRANT SELECT ON "1".likert_questions to anonymous;
+GRANT SELECT ON mappa.likert_questions to anonymous;

--- a/postgrest/Dockerfile
+++ b/postgrest/Dockerfile
@@ -1,7 +1,6 @@
-FROM        havengrc-docker.jfrog.io/postgrest/postgrest:v0.4.3.0
+FROM        havengrc-docker.jfrog.io/postgrest/postgrest:v0.5.0.0
 MAINTAINER  Kindly Ops, LLC <support@kindlyops.com>
 COPY        postgrest/config /config
-COPY        postgrest/vendor/postgrest /usr/local/bin/postgrest
 USER root
 RUN addgroup --system havenuser && adduser --system havenuser && adduser havenuser havenuser
 RUN chown -R havenuser:0 /config && \


### PR DESCRIPTION
# Description
Allows for anonymous read only access to likert questions.
Update to postgrest5.
Issue #HAV-94
## How to test

`docker-compose run apitest`
