### PR TITLE
Make dump-token portable between OSX and Linux.

### DIFF
--- a/dump-token
+++ b/dump-token
@@ -1,4 +1,18 @@
 #!/bin/bash
 TOKEN=`./get-token`
 IFS=. read header payload signature <<<"${TOKEN}"
-echo -n $payload|base64 -d -i| jq .
+# echo length of payload is  ${#payload}
+# base64 strings should have = padding to make them a multiple of 3
+# since we extract a chunk from the middle of the JWT it has no padding
+# we add padding as needed to avoid a warning from base64 decode command
+padding=""
+if (( ${#payload} % 3 == 1 ))
+then
+    #echo "Adding a double =="
+    padding="=="
+elif (( ${#payload} % 3 == 2 ))
+then
+    #echo "Adding a single ="
+    padding="="
+fi
+printf "%s%s" $payload $padding|base64 --decode|jq .


### PR DESCRIPTION
Fix all warnings.

