### PR TITLE
Upgrade to Keycloak 4.3.0-Final

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,5 +24,5 @@ container_pull(
     name = "keycloak_base",
     registry = "havengrc-docker.jfrog.io",
     repository = "jboss/keycloak",
-    tag = "4.0.0.Final",
+    tag = "4.3.0.Final",
 )

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -9,7 +9,7 @@ RUN mvn -f /keycloak-service-providers/pom.xml dependency:resolve
 COPY keycloak-service-providers /keycloak-service-providers
 RUN mvn -f /keycloak-service-providers/pom.xml clean package
 
-FROM                havengrc-docker.jfrog.io/jboss/keycloak-openshift:4.0.0.Final
+FROM                havengrc-docker.jfrog.io/jboss/keycloak-openshift:4.3.0.Final
 MAINTAINER          Kindly Ops, LLC <support@kindlyops.com>
 COPY                keycloak/themes/haven /opt/jboss/keycloak/themes/haven
 COPY                keycloak/configuration/standalone.xml /opt/jboss/keycloak/standalone/configuration/standalone.xml

--- a/keycloak/configuration/standalone.xml
+++ b/keycloak/configuration/standalone.xml
@@ -468,8 +468,8 @@
         <subsystem xmlns="urn:jboss:domain:undertow:4.0">
             <buffer-cache name="default"/>
             <server name="default-server">
-                <http-listener name="default" socket-binding="http" redirect-socket="https" proxy-address-forwarding="${env.PROXY_ADDRESS_FORWARDING}" enable-http2="true"/>
-                <https-listener name="https" socket-binding="https" security-realm="ApplicationRealm" enable-http2="true"/>
+                <http-listener name="default" socket-binding="http" redirect-socket="https" proxy-address-forwarding="${env.PROXY_ADDRESS_FORWARDING:false}" enable-http2="true"/>
+                <https-listener name="https" socket-binding="https" proxy-address-forwarding="${env.PROXY_ADDRESS_FORWARDING:false}" security-realm="ApplicationRealm" enable-http2="true"/>
                 <host name="default-host" alias="localhost">
                     <location name="/" handler="welcome-content"/>
                     <http-invoker security-realm="ApplicationRealm"/>
@@ -553,6 +553,16 @@
             <spi name="x509cert-lookup">
                 <default-provider>${keycloak.x509cert.lookup.provider:default}</default-provider>
                 <provider name="default" enabled="true"/>
+            </spi>
+            <spi name="hostname">
+                <default-provider>request</default-provider>
+                <provider name="fixed" enabled="true">
+                    <properties>
+                        <property name="hostname" value="localhost"/>
+                        <property name="httpPort" value="-1"/>
+                        <property name="httpsPort" value="-1"/>
+                    </properties>
+                </provider>
             </spi>
         </subsystem>
     </profile>


### PR DESCRIPTION
This updates from Keycloak 4.0 to 4.3. Release notes here:
https://www.keycloak.org/docs/latest/release_notes/index.html

> Keycloak 4.3.0.Final
Hostname SPI
The hostname SPI introduces a more flexible way to configure the hostname for Keycloak. There are two built-in providers. The first is request, which uses the request headers to determine the hostname. The second is fixed, which allows configuring a fixed hostname. The latter makes sure that only valid hostnames can be used and also allows internal applications to invoke Keycloak through an alternative URL.

> For more details refer to the threat mitigation section in the Server Administration Guide.

> X509 Client Authenticator
The newly added Client Authenticator uses X509 Client Certificates and Mutual TLS to secure a connection from the client. In addition to that the Keycloak Server validates Subject DN field of the client’s certificate.

> Performance improvements to Authorization Services
For this release, we improved policy evaluation performance across the board, increasing reliability and throughput. The main changes we did were related with trying to optimize the policy evaluation path by avoiding unnecessary flows and collect decisions as soon as they happen. We also introduced a policy decision cache on a per request basis, avoiding redundant decisions from policies previously evaluated.

> We are also working on other layers of cache which should give a much better experience. See KEYCLOAK-7952.

> Choosing the response mode when obtaining permissions from the server
In previous versions, permissions were always returned from the server using standard OAuth2 response, containing the access and refresh tokens. In this release, clients can use a response_mode parameter to specify how the server should respond to an authorization request. This parameter accepts two values:

> decision

> Indicating that responses should only contain a flag indicating whether or not permissions were granted by the server. Otherwise a 403 HTTP status code is returned.

> permissions

> Indicating that a response should contain every single permission granted by the server using a JSON format.

> NodeJS Policy Enforcer
The keycloak-nodejs-connect, an adapter for NodeJS, now supports constructs to protect resources based on decisions taken from the server. The new construct allows users to protect their resources using fine-grained permissions as follows:

> app.get('/protected/resource', keycloak.enforcer('resource:view'), function (req, res) {
  res.json({message: 'access granted'});
});
Support hosted domain for Google logins
Login with Google now supports the hd parameter to restrict Google logins to a specific hosted domain at Google. When this is specified in the identity provider any login from a different domain is rejected.

> Thanks to brushmate for the contribution.

> Escape unsafe tags in HTML output
Most HTML output is already escaped for HTML tags, but there are some places where HTML tags are permitted. These are only where admin access is needed to update the value. Even though it would require admin access to update such fields we have added an extra layer of defence and are now escaping unsafe elements like <script>.

> Keycloak 4.2.0.Final
Browser tab support for Cordova
We now have support for using browser tab and universal links in the JavaScript adapter for Cordova. This enables SSO between multiple applications as well as increases security.

> Thanks to gtudan for the contribution.

> SAML adapter multitenancy support
The SAML adapter can support multi-tenancy now just like the built in adapter for OpenID Connect.

> An option to create claims with dots (.) in them
In previous versions, it was not possible to create claims in the token using a claim name containing a dot (.) character. Now it is possible to escape the dot character in the configuration, so a claim name with the dot character can be used.

> Keycloak 4.1.0.Final
Making Spring Boot 2 the default starter
Starting with release 4.1, the Spring Boot starter will be based on the Spring Boot 2 adapter. If you are using an older Spring Boot version, the keycloak-legacy-spring-boot-starter is available.