### PR TITLE
Adjust security headers to fix breakages.

### DIFF
--- a/webui/Caddyfile
+++ b/webui/Caddyfile
@@ -18,7 +18,7 @@ header / {
   # Disallow the site to be rendered within a frame (clickjacking protection)
   X-Frame-Options "DENY"
   # CSP
-  Content-Security-Policy "'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';"
+  Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self' data: www.gravatar.com; style-src 'self' 'unsafe-inline'; font-src 'self' data: ;"
   Feature-Policy "autoplay 'none'; camera 'none'; microphone 'none'; midi 'none'; usb 'none'; vr 'none';"
   Referrer-Policy "strict-origin"
 }

--- a/webui/Caddyfile-dev
+++ b/webui/Caddyfile-dev
@@ -7,9 +7,9 @@ header / {
   # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
   X-Content-Type-Options "nosniff"
   # Disallow the site to be rendered within a frame (clickjacking protection)
-  X-Frame-Options "DENY"
+  X-Frame-Options "sameorigin"
   # CSP
-  Content-Security-Policy "'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';"
+  Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self' data: www.gravatar.com; style-src 'self' 'unsafe-inline';  font-src 'self' data: ;"
   Feature-Policy "autoplay 'none'; camera 'none'; microphone 'none'; midi 'none'; usb 'none'; vr 'none';"
   Referrer-Policy "strict-origin"
 }


### PR DESCRIPTION
The previous security headers were much too strict and broke things.
Revised to:
* allow loading fonts from data attributes
* allow loading images from data attributes
* allow loading images from www.gravatar.com
* allow loading frames from sameorigin (for keycloak login status hidden iframe)