### PR TITLE
Speed up start of webui container.

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build": "npm i && node scripts/build.js",
-    "start": "npm i && node scripts/start.js",
+    "build": "node scripts/build.js",
+    "start": "node scripts/start.js",
     "package": "elm-package",
     "make": "elm-make",
     "repl": "elm-repl",


### PR DESCRIPTION
We don't need to re-run npm install every time the container
starts. Instead, developers need to rebuild the container
when adding/removing packages. This will greatly speed up
startup during normal development and reduce the amount of
network traffic from repeated npm installs.

