### PR TITLE
Refactor to change SCDS survey to 1 group.

### DIFF
--- a/webui/src/Page/Survey.elm
+++ b/webui/src/Page/Survey.elm
@@ -69,6 +69,9 @@ type alias Model =
 
 --TODO: change currentSurvey to Maybe
 
+--TODO: eventually allow for configuration of total groups
+totalGroups =
+  1
 
 type alias TestStructure =
     { storedSurvey : SavedState
@@ -310,7 +313,7 @@ update msg model authModel =
                     Data.Survey.groupIpsativeSurveyData data
 
                 survey =
-                    Data.Survey.createIpsativeSurvey 10 2 model.selectedSurveyMetaData questions
+                    Data.Survey.createIpsativeSurvey 10 totalGroups model.selectedSurveyMetaData questions
             in
                 { model | currentSurvey = survey, isSurveyReady = True } ! []
 
@@ -1101,7 +1104,7 @@ viewSurveyPointsGroup : IpsativeAnswer -> PointsAssigned -> Html Msg
 viewSurveyPointsGroup answer group =
     li [ class "list-group-item" ]
         [ div [ class "d-flex justify-content-between" ]
-            [ div [ class "align-self-center" ] [ p [ class "card-text" ] [ text ("Group " ++ toString group.group ++ ":") ] ]
+            [ div [ class "align-self-center" ] []
             , div [ class "" ]
                 [ button
                     [ type_ "button"

--- a/webui/src/Page/Survey.elm
+++ b/webui/src/Page/Survey.elm
@@ -69,7 +69,6 @@ type alias Model =
 
 --TODO: change currentSurvey to Maybe
 
---TODO: eventually allow for configuration of total groups
 totalGroups =
   1
 

--- a/webui/src/Page/SurveyResponses.elm
+++ b/webui/src/Page/SurveyResponses.elm
@@ -176,7 +176,6 @@ viewResponseTable datum =
     Html.table []
         ([ Html.tr []
             [ Html.th [] [ text "Category" ]
-            , Html.th [] [ text "Group" ]
             , Html.th [] [ text "Points" ]
             ]
          ]
@@ -184,7 +183,6 @@ viewResponseTable datum =
                 (\datum ->
                     Html.tr []
                         [ Html.td [] [ text datum.category ]
-                        , Html.td [] [ text (toString datum.group) ]
                         , Html.td [] [ text (toString datum.points) ]
                         ]
                 )


### PR DESCRIPTION
This change removes the second unused group.

Issue #HAV-71

Signed-off-by: Christopher Mundus <chris@kindlyops.com>

# Description

When we conduct the SCDS diagnostic survey during an assessment, the survey is about the current state, not about the state of multiple groups.
