### PR TITLE
Don't show the SurveyInstructions page.

### DIFF
--- a/webui/src/Page/Survey.elm
+++ b/webui/src/Page/Survey.elm
@@ -49,7 +49,6 @@ import Json.Decode.Pipeline exposing (decode, required)
 
 type SurveyPage
     = Home
-    | SurveyInstructions
     | Survey
     | IncompleteSurvey
     | Finished
@@ -70,6 +69,7 @@ type alias Model =
 --TODO: change currentSurvey to Maybe
 
 
+totalGroups : number
 totalGroups =
     1
 
@@ -112,9 +112,6 @@ decodeCurrentPage =
                 case str of
                     "Home" ->
                         Decode.succeed Home
-
-                    "SurveyInstructions" ->
-                        Decode.succeed SurveyInstructions
 
                     "Survey" ->
                         Decode.succeed Survey
@@ -203,9 +200,6 @@ encodeSurveyPage surveyPage =
         Home ->
             "Home"
 
-        SurveyInstructions ->
-            "SurveyInstructions"
-
         Survey ->
             "Survey"
 
@@ -232,9 +226,7 @@ surveyRequests authModel =
 
 
 type Msg
-    = BeginLikertSurvey
-    | BeginIpsativeSurvey
-    | StartLikertSurvey SurveyMetaData
+    = StartLikertSurvey SurveyMetaData
     | StartIpsativeSurvey SurveyMetaData
     | IncrementAnswer IpsativeAnswer Int
     | DecrementAnswer IpsativeAnswer Int
@@ -377,20 +369,6 @@ update msg model authModel =
                         { model | currentPage = Finished }
                     else
                         { model | currentPage = IncompleteSurvey }
-            in
-                newModel ! [ (storeSurvey newModel (getQuestionNumber newModel)) ]
-
-        BeginLikertSurvey ->
-            let
-                newModel =
-                    { model | currentPage = Survey }
-            in
-                newModel ! [ (storeSurvey newModel (getQuestionNumber newModel)) ]
-
-        BeginIpsativeSurvey ->
-            let
-                newModel =
-                    { model | currentPage = Survey }
             in
                 newModel ! [ (storeSurvey newModel (getQuestionNumber newModel)) ]
 
@@ -775,9 +753,6 @@ view authModel model =
         Home ->
             viewHero model
 
-        SurveyInstructions ->
-            viewSurveyInstructions model.currentSurvey model.isSurveyReady
-
         Survey ->
             viewSurvey model.currentSurvey
 
@@ -809,46 +784,6 @@ viewIncompleteButtons survey questionNumbers =
             div [ class "my-2" ] [ button [ class "btn btn-primary", onClick (GotoQuestion questionNumber) ] [ text ("Click to go back to question " ++ toString questionNumber) ] ]
         )
         questionNumbers
-
-
-viewSurveyInstructions : Survey -> Bool -> Html Msg
-viewSurveyInstructions survey isSurveyReady =
-    case survey of
-        Ipsative survey ->
-            viewIpsativeSurveyInstructions survey isSurveyReady
-
-        Likert survey ->
-            viewLikertSurveyInstructions survey isSurveyReady
-
-
-viewIpsativeSurveyInstructions : IpsativeSurvey -> Bool -> Html Msg
-viewIpsativeSurveyInstructions survey isSurveyReady =
-    div [ class "pt-3" ]
-        [ div [ class "row" ]
-            [ div
-                [ class "col" ]
-                [ h1 [ class "display-4" ] [ text survey.metaData.name ]
-                , p [ class "lead" ] [ text survey.metaData.instructions ]
-                , hr [ class "my-4" ] []
-                , button [ class "btn btn-primary", disabled (not isSurveyReady), onClick BeginIpsativeSurvey ] [ text "Begin" ]
-                ]
-            ]
-        ]
-
-
-viewLikertSurveyInstructions : LikertSurvey -> Bool -> Html Msg
-viewLikertSurveyInstructions survey isSurveyReady =
-    div [ class "pt-3" ]
-        [ div [ class "row" ]
-            [ div
-                [ class "col" ]
-                [ h1 [ class "display-4" ] [ text survey.metaData.name ]
-                , p [ class "lead" ] [ text survey.metaData.instructions ]
-                , hr [ class "my-4" ] []
-                , button [ class "btn btn-primary", disabled (not isSurveyReady), onClick BeginLikertSurvey ] [ text "Begin" ]
-                ]
-            ]
-        ]
 
 
 getTotalAvailableSurveys : Model -> Int

--- a/webui/src/Page/Survey.elm
+++ b/webui/src/Page/Survey.elm
@@ -69,8 +69,10 @@ type alias Model =
 
 --TODO: change currentSurvey to Maybe
 
+
 totalGroups =
-  1
+    1
+
 
 type alias TestStructure =
     { storedSurvey : SavedState
@@ -393,10 +395,10 @@ update msg model authModel =
                 newModel ! [ (storeSurvey newModel (getQuestionNumber newModel)) ]
 
         StartLikertSurvey metaData ->
-            { model | currentPage = SurveyInstructions, selectedSurveyMetaData = metaData } ! [ Http.send GotLikertServerData (Request.Survey.getLikertSurvey authModel metaData.uuid) ]
+            { model | currentPage = Survey, selectedSurveyMetaData = metaData } ! [ Http.send GotLikertServerData (Request.Survey.getLikertSurvey authModel metaData.uuid) ]
 
         StartIpsativeSurvey metaData ->
-            { model | currentPage = SurveyInstructions, selectedSurveyMetaData = metaData } ! [ Http.send GotIpsativeServerData (Request.Survey.getIpsativeSurvey authModel metaData.uuid) ]
+            { model | currentPage = Survey, selectedSurveyMetaData = metaData } ! [ Http.send GotIpsativeServerData (Request.Survey.getIpsativeSurvey authModel metaData.uuid) ]
 
         NextQuestion ->
             case model.currentSurvey of
@@ -921,7 +923,17 @@ viewLikertSurvey survey =
         , br [] []
         , viewLikertSurveyTable (Zipper.current survey.questions)
         , br [] []
+        , viewInlineSurveyInstructions survey.metaData.instructions
         , viewSurveyFooter
+        ]
+
+
+viewInlineSurveyInstructions : String -> Html Msg
+viewInlineSurveyInstructions instructions =
+    div [ class "row" ]
+        [ div
+            [ class "col-lg h5", style [ ( "text-align", "center" ) ] ]
+            [ text instructions ]
         ]
 
 
@@ -995,6 +1007,7 @@ viewIpsativeSurvey survey =
         , br [] []
         , viewIpsativeSurveyBoxes (Zipper.current survey.questions)
         , br [] []
+        , viewInlineSurveyInstructions survey.metaData.instructions
         , viewSurveyFooter
         ]
 


### PR DESCRIPTION
Tiny steps towards streamlining the surveys.

The SurveyInstructions page at the beginning of a survey is an extra click that is
unneeded. Jump right into the survey and show the instructions
on every page of the survey.

Styling is still needed, this is just the structural change.