### PR TITLE
Refactor to add slack notification.

### DIFF
--- a/havenapi/actions/registration_funnel.go
+++ b/havenapi/actions/registration_funnel.go
@@ -1,7 +1,10 @@
 package actions
 
 import (
+	"bytes"
 	"fmt"
+	"net/http"
+	"os"
 	"strings"
 
 	faktory "github.com/contribsys/faktory/client"
@@ -50,8 +53,43 @@ func RegistrationHandler(c buffalo.Context) error {
 	if err != nil {
 		return c.Error(500, err)
 	}
+	message := fmt.Sprintf("New registration for: %s", request.FormValue("email"))
+	_ = sendSlackNotification(message)
 
-	log.Info("processed a registration")
-	message := "success"
+	log.Info(message)
+
 	return c.Render(200, r.JSON(map[string]string{"message": message}))
+}
+
+func sendSlackNotification(msg string) error {
+	slackURL, ok := getEnv("SLACK_WEBHOOK")
+	if !ok {
+		return fmt.Errorf("No Slack Webhook found")
+	}
+	client := &http.Client{}
+
+	var jsonStr = []byte(fmt.Sprintf(`{"text": "%s"}`, msg))
+	body := bytes.NewBuffer(jsonStr)
+	req, err := http.NewRequest("POST", slackURL, body)
+	if err != nil {
+		return fmt.Errorf("Error creating slack webhook: %s", err.Error())
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Error sending slack webhook: %s", err.Error())
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func getEnv(key string) (string, bool) {
+	// Default returns false to signify no such env var.
+	err := false
+	if value, ok := os.LookupEnv(key); ok {
+		return value, ok
+	}
+	return "", err
 }

--- a/havenapi/actions/registration_funnel_test.go
+++ b/havenapi/actions/registration_funnel_test.go
@@ -1,0 +1,15 @@
+package actions
+
+import (
+	"testing"
+)
+
+func TestSendSlackNotification(t *testing.T) {
+	err := sendSlackNotification("Testing the Slack Notification from go test.")
+	if err != nil {
+		if err.Error() == "No Slack Webhook found" {
+			t.Skip("No SLACK_WEBHOOK environment variable")
+		}
+		t.Errorf("Failed test because: %s", err.Error())
+	}
+}


### PR DESCRIPTION
Now sends slack notification when a user inits
a registration with the funnel. Includes a test.
The SLACK_WEBHOOK env var must be set with the
webhook URL of your choice.

Issue #HAV-149
