### PR TITLE
Workaround for HAV-192, docker-compose errors on Windows.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
   cadvisor:
     image: google/cadvisor
     volumes:
-      - /:/rootfs:ro
+      - /../:/rootfs:ro
       - /var/run:/var/run:rw
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro


### PR DESCRIPTION
Workaround from https://github.com/docker/compose/issues/3285#issuecomment-207443423

This tries to work around the volume mount error that @laurencaitlan was getting on windows hosts.