### PR TITLE
Don't deploy worker image via jfrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ jobs:
             oc set image deployment/havenapi havenapi=havengrc-docker.jfrog.io/kindlyops/havenapi:$CIRCLE_SHA1
             oc set image deployment/havenweb havenweb=havengrc-docker.jfrog.io/kindlyops/havenweb:$CIRCLE_SHA1
             oc set image deployment/keycloak keycloak=havengrc-docker.jfrog.io/kindlyops/keycloak:$CIRCLE_SHA1
-            oc set image deployment/worker   worker=havengrc-docker.jfrog.io/kindlyops/havenworker:$CIRCLE_SHA1
+            oc set image deployment/worker   worker=kindlyops/havenworker:$CIRCLE_SHA1
       - run:
           name: notify failed job
           command: ./notify-slack notifications "CircleCI pipeline for ${CIRCLE_PULL_REQUEST:-$CIRCLE_BRANCH} failed in $CIRCLE_JOB $CIRCLE_BUILD_URL" circleci


### PR DESCRIPTION
It seems like jfrog has trouble with larger images,
bypassing for now and having the k8s deployment pull directly from docker hub to remove one more source of troubleshooting.
