### PR TITLE
try setlocation href workaround for safari mask

### DIFF
--- a/webui/src/index.js
+++ b/webui/src/index.js
@@ -136,10 +136,11 @@ document.arrive("#lottie", () => {
   var animationPath = process.env.PUBLIC_URL + '/animations/haven-demo.json'
   if (element) {
     console.log("got lottie element");
+    lottie.setLocationHref(document.location.href)
     lottie.loadAnimation({
       container: element, // Required
       path: animationPath, // Required
-      renderer: 'canvas', // Required
+      renderer: 'svg', // Required
       loop: true, // Optional
       autoplay: true, // Optional
     });


### PR DESCRIPTION
trying a workaround from https://github.com/airbnb/lottie-web/issues/914 to see if it makes lottie animation work on mobile safari.